### PR TITLE
use Illuminate\Support\Str

### DIFF
--- a/wave/src/Plan.php
+++ b/wave/src/Plan.php
@@ -4,6 +4,7 @@ namespace Wave;
 
 use Illuminate\Database\Eloquent\Model;
 use TCG\Voyager\Models\Role;
+use Illuminate\Support\Str;
 
 class Plan extends Model
 {


### PR DESCRIPTION
When I try to add a Plan, I get the following stacktrace : 
```
[2021-05-07 14:22:22] local.ERROR: Class 'Wave\Str' not found {"userId":1,"exception":"[object] (Error(code: 0): Class 'Wave\\Str' not found at /var/www/html/wave/src/Plan.php:15)
[stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(392): Wave\\Plan::Wave\\{closure}()

```

Here is my sail docker-compose.yml file : 

```
# For more information: https://laravel.com/docs/sail
version: '3'
services:
    laravel.test:
        build:
            context: ./vendor/laravel/sail/runtimes/7.4
            dockerfile: Dockerfile
            args:
                WWWGROUP: '${WWWGROUP}'
        image: sail-7.0/app
        ports:
            - '${APP_PORT:-80}:80'
        environment:
            WWWUSER: '${WWWUSER}'
            LARAVEL_SAIL: 1
        volumes:
            - '.:/var/www/html'
        networks:
            - sail
        depends_on:
            - mysql
    mysql:
        image: 'mysql:8.0'
        ports:
            - '${FORWARD_DB_PORT:-3306}:3306'
        environment:
            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
            MYSQL_DATABASE: '${DB_DATABASE}'
            MYSQL_USER: '${DB_USERNAME}'
            MYSQL_PASSWORD: '${DB_PASSWORD}'
            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
        volumes:
            - 'sailwave:/var/lib/mysql'
        networks:
            - sail
        healthcheck:
          test: ["CMD", "mysqladmin", "ping"]
    mailhog:
        image: 'mailhog/mailhog:latest'
        ports:
            - '${FORWARD_MAILHOG_PORT:-1025}:1025'
            - '${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025'
        networks:
            - sail
networks:
    sail:
        driver: bridge
volumes:
    sailwave:
        driver: local
```