### PR TITLE
Match default laravel config better. Main reason it to user using php…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,104 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Laravel template
+vendor/*
+node_modules/*
+npm-debug.log
+
+/storage/api-docs
+/storage/app
+/storage/framework/views
+/storage/framework/cache
+/storage/framework/sessions
+/storage/framework/testing
+/storage/framework/logs
+/storage/logs
+
+# Laravel 4 specific
+bootstrap/compiled.php
+app/storage/
+
+# Laravel 5 & Lumen specific
+public/storage
+public/hot
+.env.*.php
+.env.php
+.env
+Homestead.yaml
+Homestead.json
+
+# Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
+.rocketeer/
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+#storage/*.key
+
+/cronFile
+
+/storage/GeoLite2-City.mmdb
+
+.idea
+.git
+
+#/storage/*.key
+!.gitignore
+!.gitkeep
+!.gitmodules
+
+!/storage/framework/views/.gitignore
+!/storage/logs/.gitignore
+!/storage/framework/testing/disks/local/.gitkeep
+!/storage/framework/views/.gitkeep
+!/storage/logs/.gitkeep
+!/storage/app/dashboard/tmp/.gitkeep
+!/storage/app/public/.gitkeep
+!/storage/api-docs/.gitkeep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haakco/stage3-ubuntu-20.04-php7.4-lv-docker
+FROM haakco/stage3-ubuntu-20.04-php7.4-lv
 
 USER www-data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM haakco/stage3-ubuntu-20.04-php7.4-lv-docker
+
+USER www-data
+
+## Cleanout previous dev just in case
+RUN rm -rf /var/www/site/*
+
+ADD --chown=www-data:www-data . /var/www/site
+
+WORKDIR /var/www/site
+
+RUN composer install --no-ansi --no-suggest --no-scripts --prefer-dist --no-progress --no-interaction \
+      --optimize-autoloader
+
+USER root
+
+RUN find /usr/share/GeoIP -not -user www-data -execdir chown "www-data:" {} \+ && \
+    find /var/www/site -not -user www-data -execdir chown "www-data:" {} \+
+
+#HEALTHCHECK \
+#  --interval=30s \
+#  --timeout=60s \
+#  --retries=10 \
+#  --start-period=60s \
+#  CMD if [[ "$(curl -f http://127.0.0.1/ | jq -e . >/dev/null 2>&1)" != "0" ]]; then exit 1; else exit 0; fi

--- a/buildDocker.sh
+++ b/buildDocker.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
-export PROXY="${PROXY:-""}"
-export IMAGE_NAME="${IMAGE_NAME}"
+export IMAGE_NAME='haakco/stage3-ubuntu-20.04-php7.4-lv-wave'
 export DOCKER_FILE="${DOCKER_FILE:-"Dockerfile"}"
 
-echo "Proxy Set to: ${PROXY}"
 echo "Tagged as : ${IMAGE_NAME}"
 echo ""
 echo ""
 
-CMD='docker build --rm --build-arg PROXY='"${PROXY}"' --file '"${DOCKER_FILE}"' -t '"${IMAGE_NAME}"' .'
+CMD='docker build --rm --file '"${DOCKER_FILE}"' -t '"${IMAGE_NAME}"' .'
 
 echo "Build commmand: ${CMD}"
 echo ""

--- a/buildDocker.sh
+++ b/buildDocker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+export PROXY="${PROXY:-""}"
+export IMAGE_NAME="${IMAGE_NAME}"
+export DOCKER_FILE="${DOCKER_FILE:-"Dockerfile"}"
+
+echo "Proxy Set to: ${PROXY}"
+echo "Tagged as : ${IMAGE_NAME}"
+echo ""
+echo ""
+
+CMD='docker build --rm --build-arg PROXY='"${PROXY}"' --file '"${DOCKER_FILE}"' -t '"${IMAGE_NAME}"' .'
+
+echo "Build commmand: ${CMD}"
+echo ""
+${CMD}

--- a/config/app.php
+++ b/config/app.php
@@ -39,7 +39,7 @@ return [
     |
     */
 
-    'debug' => env('APP_DEBUG', false),
+    'debug' => (bool) env('APP_DEBUG', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -53,6 +53,8 @@ return [
     */
 
     'url' => env('APP_URL', 'http://localhost'),
+
+    'asset_url' => env('ASSET_URL', null),
 
     /*
     |--------------------------------------------------------------------------
@@ -92,6 +94,19 @@ return [
     */
 
     'fallback_locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Faker Locale
+    |--------------------------------------------------------------------------
+    |
+    | This locale will be used by the Faker PHP library when generating fake
+    | data for your database seeds. For example, this will be used to get
+    | localized telephone numbers, street address information and more.
+    |
+    */
+
+    'faker_locale' => 'en_US',
 
     /*
     |--------------------------------------------------------------------------
@@ -197,6 +212,7 @@ return [
     'aliases' => [
 
         'App' => Illuminate\Support\Facades\App::class,
+        'Arr' => Illuminate\Support\Arr::class,
         'Artisan' => Illuminate\Support\Facades\Artisan::class,
         'Auth' => Illuminate\Support\Facades\Auth::class,
         'Blade' => Illuminate\Support\Facades\Blade::class,
@@ -206,12 +222,14 @@ return [
         'Config' => Illuminate\Support\Facades\Config::class,
         'Cookie' => Illuminate\Support\Facades\Cookie::class,
         'Crypt' => Illuminate\Support\Facades\Crypt::class,
+        'Date' => Illuminate\Support\Facades\Date::class,
         'DB' => Illuminate\Support\Facades\DB::class,
         'Eloquent' => Illuminate\Database\Eloquent\Model::class,
         'Event' => Illuminate\Support\Facades\Event::class,
         'File' => Illuminate\Support\Facades\File::class,
         'Gate' => Illuminate\Support\Facades\Gate::class,
         'Hash' => Illuminate\Support\Facades\Hash::class,
+        'Http' => Illuminate\Support\Facades\Http::class,
         'Lang' => Illuminate\Support\Facades\Lang::class,
         'Log' => Illuminate\Support\Facades\Log::class,
         'Mail' => Illuminate\Support\Facades\Mail::class,
@@ -226,6 +244,7 @@ return [
         'Schema' => Illuminate\Support\Facades\Schema::class,
         'Session' => Illuminate\Support\Facades\Session::class,
         'Storage' => Illuminate\Support\Facades\Storage::class,
+        'Str' => Illuminate\Support\Str::class,
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -35,12 +37,15 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
+            'url' => env('DATABASE_URL'),
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],
 
         'mysql' => [
             'driver' => 'mysql',
+            'url' => env('DATABASE_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'forge'),
@@ -50,12 +55,17 @@ return [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
+            'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
         ],
 
         'pgsql' => [
             'driver' => 'pgsql',
+            'url' => env('DATABASE_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'forge'),
@@ -63,12 +73,14 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
+            'prefix_indexes' => true,
             'schema' => 'public',
             'sslmode' => 'prefer',
         ],
 
         'sqlsrv' => [
             'driver' => 'sqlsrv',
+            'url' => env('DATABASE_URL'),
             'host' => env('DB_HOST', 'localhost'),
             'port' => env('DB_PORT', '1433'),
             'database' => env('DB_DATABASE', 'forge'),
@@ -76,6 +88,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
+            'prefix_indexes' => true,
         ],
 
     ],
@@ -106,13 +119,27 @@ return [
 
     'redis' => [
 
-        'client' => 'predis',
+        'client' => env('REDIS_CLIENT', 'predis'),
+
+        'options' => [
+            'cluster' => env('REDIS_CLUSTER', 'redis'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
+        ],
 
         'default' => [
+            'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
-            'database' => 0,
+            'database' => env('REDIS_DB', '0'),
+        ],
+
+        'cache' => [
+            'url' => env('REDIS_URL'),
+            'host' => env('REDIS_HOST', '127.0.0.1'),
+            'password' => env('REDIS_PASSWORD', null),
+            'port' => env('REDIS_PORT', '6379'),
+            'database' => env('REDIS_CACHE_DB', '1'),
         ],
 
     ],

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are
+     * supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar
+     * within TrustedProxy to trust any proxy
+     * that connects directly to your server,
+     * a requirement when you cannot know the address
+     * of your proxy (e.g. if using ELB or similar).
+     *
+     */
+    'proxies' => explode(',', env('TRUSTED_PROXIES', null)), // [<ip addresses>,], '*', '<ip addresses>,'
+
+    /*
+     * To trust one or more specific proxies that connect
+     * directly to your server, use an array or a string separated by comma of IP addresses:
+     */
+    // 'proxies' => ['192.168.1.1'],
+    // 'proxies' => '192.168.1.1, 192.168.1.2',
+
+    /*
+     * Or, to trust all proxies that connect
+     * directly to your server, use a "*"
+     */
+    // 'proxies' => '*',
+
+    /*
+     * Which headers to use to detect proxy related data (For, Host, Proto, Port)
+     *
+     * Options include:
+     *
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
+     * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB (If you are using AWS Elastic Load Balancer)
+     *
+     * - 'HEADER_X_FORWARDED_ALL' (use all x-forwarded-* headers to establish trust)
+     * - 'HEADER_FORWARDED' (use the FORWARDED header to establish trust)
+     * - 'HEADER_X_FORWARDED_AWS_ELB' (If you are using AWS Elastic Load Balancer)
+     *
+     * @link https://symfony.com/doc/current/deployment/proxies.html
+     */
+    'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL,
+
+];

--- a/public/storage
+++ b/public/storage
@@ -1,0 +1,1 @@
+../storage/app/public


### PR DESCRIPTION
Hi

I wanted to rather use phpredis over predis.

But there was no env variable to allow this.

So I've gone over what a default install database config looks like and added any of the missing settings.

Though I've left it so that predis is still the default. But you can now override it with.

REDIS_CLIENT