### PR TITLE
Remove explicit values from seeders incrementing column

### DIFF
--- a/database/seeders/AnnouncementsTableSeeder.php
+++ b/database/seeders/AnnouncementsTableSeeder.php
@@ -21,7 +21,6 @@ class AnnouncementsTableSeeder extends Seeder
         \DB::table('announcements')->insert(array (
             0 =>
             array (
-                'id' => 1,
                 'title' => 'Wave 1.0 Released',
                 'description' => 'We have just released the first official version of Wave. Click here to learn more!',
                 'body' => '<p>It\'s been a fun Journey creating this awesome SAAS starter kit and we are super excited to use it in many of our future projects. There are just so many features that Wave has that will make building the SAAS of your dreams easier than ever before.</p>
@@ -34,7 +33,6 @@ class AnnouncementsTableSeeder extends Seeder
         \DB::table('announcements')->insert(array (
             1 =>
             array (
-                'id' => 2,
                 'title' => 'Wave 2.0 Released',
                 'description' => 'Wave V2 has been released with some awesome new features. Be sure to read up on what\'s new!',
                 'body' => '<p>This new version of Wave includes the following updates:</p><ul><li>Update to the latest version of Laravel</li><li>New Payment integration with Paddle</li><li>Rewritten theme support</li><li>Deployment integration</li><li>Much more awesomeness</li></ul><p>Be sure to check out the official Wave v2 page at <a href="https://devdojo.com/wave">https://devdojo.com/wave</a></p>',

--- a/database/seeders/CategoriesTableSeeder.php
+++ b/database/seeders/CategoriesTableSeeder.php
@@ -21,7 +21,6 @@ class CategoriesTableSeeder extends Seeder
         \DB::table('categories')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'parent_id' => NULL,
                 'order' => 1,
                 'name' => 'Category 1',
@@ -31,7 +30,6 @@ class CategoriesTableSeeder extends Seeder
             ),
             1 => 
             array (
-                'id' => 2,
                 'parent_id' => NULL,
                 'order' => 1,
                 'name' => 'Category 2',

--- a/database/seeders/DataRowsTableSeeder.php
+++ b/database/seeders/DataRowsTableSeeder.php
@@ -21,7 +21,6 @@ class DataRowsTableSeeder extends Seeder
         \DB::table('data_rows')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'data_type_id' => 1,
                 'field' => 'id',
                 'type' => 'number',
@@ -37,7 +36,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             1 => 
             array (
-                'id' => 2,
                 'data_type_id' => 1,
                 'field' => 'author_id',
                 'type' => 'text',
@@ -53,7 +51,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             2 => 
             array (
-                'id' => 3,
                 'data_type_id' => 1,
                 'field' => 'category_id',
                 'type' => 'text',
@@ -69,7 +66,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             3 => 
             array (
-                'id' => 4,
                 'data_type_id' => 1,
                 'field' => 'title',
                 'type' => 'text',
@@ -85,7 +81,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             4 => 
             array (
-                'id' => 5,
                 'data_type_id' => 1,
                 'field' => 'excerpt',
                 'type' => 'text_area',
@@ -101,7 +96,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             5 => 
             array (
-                'id' => 6,
                 'data_type_id' => 1,
                 'field' => 'body',
                 'type' => 'rich_text_box',
@@ -117,7 +111,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             6 => 
             array (
-                'id' => 7,
                 'data_type_id' => 1,
                 'field' => 'image',
                 'type' => 'image',
@@ -133,7 +126,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             7 => 
             array (
-                'id' => 8,
                 'data_type_id' => 1,
                 'field' => 'slug',
                 'type' => 'text',
@@ -149,7 +141,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             8 => 
             array (
-                'id' => 9,
                 'data_type_id' => 1,
                 'field' => 'meta_description',
                 'type' => 'text_area',
@@ -165,7 +156,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             9 => 
             array (
-                'id' => 10,
                 'data_type_id' => 1,
                 'field' => 'meta_keywords',
                 'type' => 'text_area',
@@ -181,7 +171,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             10 => 
             array (
-                'id' => 11,
                 'data_type_id' => 1,
                 'field' => 'status',
                 'type' => 'select_dropdown',
@@ -197,7 +186,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             11 => 
             array (
-                'id' => 12,
                 'data_type_id' => 1,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -213,7 +201,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             12 => 
             array (
-                'id' => 13,
                 'data_type_id' => 1,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -229,7 +216,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             13 => 
             array (
-                'id' => 14,
                 'data_type_id' => 2,
                 'field' => 'id',
                 'type' => 'number',
@@ -245,7 +231,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             14 => 
             array (
-                'id' => 15,
                 'data_type_id' => 2,
                 'field' => 'author_id',
                 'type' => 'text',
@@ -261,7 +246,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             15 => 
             array (
-                'id' => 16,
                 'data_type_id' => 2,
                 'field' => 'title',
                 'type' => 'text',
@@ -277,7 +261,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             16 => 
             array (
-                'id' => 17,
                 'data_type_id' => 2,
                 'field' => 'excerpt',
                 'type' => 'text_area',
@@ -293,7 +276,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             17 => 
             array (
-                'id' => 18,
                 'data_type_id' => 2,
                 'field' => 'body',
                 'type' => 'rich_text_box',
@@ -309,7 +291,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             18 => 
             array (
-                'id' => 19,
                 'data_type_id' => 2,
                 'field' => 'slug',
                 'type' => 'text',
@@ -325,7 +306,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             19 => 
             array (
-                'id' => 20,
                 'data_type_id' => 2,
                 'field' => 'meta_description',
                 'type' => 'text',
@@ -341,7 +321,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             20 => 
             array (
-                'id' => 21,
                 'data_type_id' => 2,
                 'field' => 'meta_keywords',
                 'type' => 'text',
@@ -357,7 +336,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             21 => 
             array (
-                'id' => 22,
                 'data_type_id' => 2,
                 'field' => 'status',
                 'type' => 'select_dropdown',
@@ -373,7 +351,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             22 => 
             array (
-                'id' => 23,
                 'data_type_id' => 2,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -389,7 +366,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             23 => 
             array (
-                'id' => 24,
                 'data_type_id' => 2,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -405,7 +381,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             24 => 
             array (
-                'id' => 25,
                 'data_type_id' => 2,
                 'field' => 'image',
                 'type' => 'image',
@@ -421,7 +396,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             25 => 
             array (
-                'id' => 26,
                 'data_type_id' => 3,
                 'field' => 'id',
                 'type' => 'number',
@@ -437,7 +411,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             26 => 
             array (
-                'id' => 27,
                 'data_type_id' => 3,
                 'field' => 'name',
                 'type' => 'text',
@@ -453,7 +426,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             27 => 
             array (
-                'id' => 28,
                 'data_type_id' => 3,
                 'field' => 'email',
                 'type' => 'text',
@@ -469,7 +441,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             28 => 
             array (
-                'id' => 29,
                 'data_type_id' => 3,
                 'field' => 'password',
                 'type' => 'password',
@@ -485,7 +456,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             29 => 
             array (
-                'id' => 30,
                 'data_type_id' => 3,
                 'field' => 'user_belongsto_role_relationship',
                 'type' => 'relationship',
@@ -501,7 +471,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             30 => 
             array (
-                'id' => 31,
                 'data_type_id' => 3,
                 'field' => 'remember_token',
                 'type' => 'text',
@@ -517,7 +486,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             31 => 
             array (
-                'id' => 32,
                 'data_type_id' => 3,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -533,7 +501,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             32 => 
             array (
-                'id' => 33,
                 'data_type_id' => 3,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -549,7 +516,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             33 => 
             array (
-                'id' => 34,
                 'data_type_id' => 3,
                 'field' => 'avatar',
                 'type' => 'image',
@@ -565,7 +531,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             34 => 
             array (
-                'id' => 35,
                 'data_type_id' => 5,
                 'field' => 'id',
                 'type' => 'number',
@@ -581,7 +546,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             35 => 
             array (
-                'id' => 36,
                 'data_type_id' => 5,
                 'field' => 'name',
                 'type' => 'text',
@@ -597,7 +561,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             36 => 
             array (
-                'id' => 37,
                 'data_type_id' => 5,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -613,7 +576,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             37 => 
             array (
-                'id' => 38,
                 'data_type_id' => 5,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -629,7 +591,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             38 => 
             array (
-                'id' => 39,
                 'data_type_id' => 4,
                 'field' => 'id',
                 'type' => 'number',
@@ -645,7 +606,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             39 => 
             array (
-                'id' => 40,
                 'data_type_id' => 4,
                 'field' => 'parent_id',
                 'type' => 'select_dropdown',
@@ -661,7 +621,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             40 => 
             array (
-                'id' => 41,
                 'data_type_id' => 4,
                 'field' => 'order',
                 'type' => 'text',
@@ -677,7 +636,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             41 => 
             array (
-                'id' => 42,
                 'data_type_id' => 4,
                 'field' => 'name',
                 'type' => 'text',
@@ -693,7 +651,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             42 => 
             array (
-                'id' => 43,
                 'data_type_id' => 4,
                 'field' => 'slug',
                 'type' => 'text',
@@ -709,7 +666,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             43 => 
             array (
-                'id' => 44,
                 'data_type_id' => 4,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -725,7 +681,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             44 => 
             array (
-                'id' => 45,
                 'data_type_id' => 4,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -741,7 +696,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             45 => 
             array (
-                'id' => 46,
                 'data_type_id' => 6,
                 'field' => 'id',
                 'type' => 'number',
@@ -757,7 +711,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             46 => 
             array (
-                'id' => 47,
                 'data_type_id' => 6,
                 'field' => 'name',
                 'type' => 'text',
@@ -773,7 +726,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             47 => 
             array (
-                'id' => 48,
                 'data_type_id' => 6,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -789,7 +741,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             48 => 
             array (
-                'id' => 49,
                 'data_type_id' => 6,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -805,7 +756,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             49 => 
             array (
-                'id' => 50,
                 'data_type_id' => 6,
                 'field' => 'display_name',
                 'type' => 'text',
@@ -821,7 +771,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             50 => 
             array (
-                'id' => 51,
                 'data_type_id' => 1,
                 'field' => 'seo_title',
                 'type' => 'text',
@@ -837,7 +786,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             51 => 
             array (
-                'id' => 52,
                 'data_type_id' => 1,
                 'field' => 'featured',
                 'type' => 'checkbox',
@@ -853,7 +801,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             52 => 
             array (
-                'id' => 53,
                 'data_type_id' => 3,
                 'field' => 'role_id',
                 'type' => 'text',
@@ -869,7 +816,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             53 => 
             array (
-                'id' => 54,
                 'data_type_id' => 3,
                 'field' => 'username',
                 'type' => 'text',
@@ -885,7 +831,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             54 => 
             array (
-                'id' => 55,
                 'data_type_id' => 7,
                 'field' => 'id',
                 'type' => 'hidden',
@@ -901,7 +846,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             55 => 
             array (
-                'id' => 56,
                 'data_type_id' => 7,
                 'field' => 'title',
                 'type' => 'text',
@@ -917,7 +861,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             56 => 
             array (
-                'id' => 57,
                 'data_type_id' => 7,
                 'field' => 'description',
                 'type' => 'text_area',
@@ -933,7 +876,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             57 => 
             array (
-                'id' => 58,
                 'data_type_id' => 7,
                 'field' => 'body',
                 'type' => 'rich_text_box',
@@ -949,7 +891,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             58 => 
             array (
-                'id' => 59,
                 'data_type_id' => 7,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -965,7 +906,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             59 => 
             array (
-                'id' => 60,
                 'data_type_id' => 7,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -981,7 +921,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             60 => 
             array (
-                'id' => 61,
                 'data_type_id' => 3,
                 'field' => 'settings',
                 'type' => 'hidden',
@@ -997,7 +936,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             61 => 
             array (
-                'id' => 62,
                 'data_type_id' => 3,
                 'field' => 'user_belongstomany_role_relationship',
                 'type' => 'relationship',
@@ -1013,7 +951,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             62 => 
             array (
-                'id' => 63,
                 'data_type_id' => 3,
                 'field' => 'locale',
                 'type' => 'text',
@@ -1029,7 +966,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             63 => 
             array (
-                'id' => 64,
                 'data_type_id' => 8,
                 'field' => 'id',
                 'type' => 'hidden',
@@ -1045,7 +981,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             64 => 
             array (
-                'id' => 65,
                 'data_type_id' => 8,
                 'field' => 'name',
                 'type' => 'text',
@@ -1061,7 +996,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             65 => 
             array (
-                'id' => 66,
                 'data_type_id' => 8,
                 'field' => 'description',
                 'type' => 'text_area',
@@ -1077,7 +1011,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             66 => 
             array (
-                'id' => 67,
                 'data_type_id' => 8,
                 'field' => 'features',
                 'type' => 'text_area',
@@ -1093,7 +1026,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             67 => 
             array (
-                'id' => 69,
                 'data_type_id' => 8,
                 'field' => 'role_id',
                 'type' => 'text',
@@ -1109,7 +1041,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             68 => 
             array (
-                'id' => 70,
                 'data_type_id' => 8,
                 'field' => 'created_at',
                 'type' => 'timestamp',
@@ -1125,7 +1056,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             69 => 
             array (
-                'id' => 71,
                 'data_type_id' => 8,
                 'field' => 'updated_at',
                 'type' => 'timestamp',
@@ -1141,7 +1071,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             70 => 
             array (
-                'id' => 72,
                 'data_type_id' => 8,
                 'field' => 'plan_belongsto_role_relationship',
                 'type' => 'relationship',
@@ -1157,7 +1086,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             71 => 
             array (
-                'id' => 73,
                 'data_type_id' => 8,
                 'field' => 'default',
                 'type' => 'checkbox',
@@ -1173,7 +1101,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             72 => 
             array (
-                'id' => 74,
                 'data_type_id' => 8,
                 'field' => 'price',
                 'type' => 'text',
@@ -1189,7 +1116,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             73 => 
             array (
-                'id' => 75,
                 'data_type_id' => 8,
                 'field' => 'plan_id',
                 'type' => 'text',
@@ -1205,7 +1131,6 @@ class DataRowsTableSeeder extends Seeder
             ),
             74 => 
             array (
-                'id' => 76,
                 'data_type_id' => 8,
                 'field' => 'trial_days',
                 'type' => 'number',

--- a/database/seeders/DataTypesTableSeeder.php
+++ b/database/seeders/DataTypesTableSeeder.php
@@ -21,7 +21,6 @@ class DataTypesTableSeeder extends Seeder
         \DB::table('data_types')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'name' => 'posts',
                 'slug' => 'posts',
                 'display_name_singular' => 'Post',
@@ -39,7 +38,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             1 => 
             array (
-                'id' => 2,
                 'name' => 'pages',
                 'slug' => 'pages',
                 'display_name_singular' => 'Page',
@@ -57,7 +55,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             2 => 
             array (
-                'id' => 3,
                 'name' => 'users',
                 'slug' => 'users',
                 'display_name_singular' => 'User',
@@ -75,7 +72,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             3 => 
             array (
-                'id' => 4,
                 'name' => 'categories',
                 'slug' => 'categories',
                 'display_name_singular' => 'Category',
@@ -93,7 +89,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             4 => 
             array (
-                'id' => 5,
                 'name' => 'menus',
                 'slug' => 'menus',
                 'display_name_singular' => 'Menu',
@@ -111,7 +106,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             5 => 
             array (
-                'id' => 6,
                 'name' => 'roles',
                 'slug' => 'roles',
                 'display_name_singular' => 'Role',
@@ -129,7 +123,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             6 => 
             array (
-                'id' => 7,
                 'name' => 'announcements',
                 'slug' => 'announcements',
                 'display_name_singular' => 'Announcement',
@@ -147,7 +140,6 @@ class DataTypesTableSeeder extends Seeder
             ),
             7 => 
             array (
-                'id' => 8,
                 'name' => 'plans',
                 'slug' => 'plans',
                 'display_name_singular' => 'Plan',

--- a/database/seeders/MenuItemsTableSeeder.php
+++ b/database/seeders/MenuItemsTableSeeder.php
@@ -21,7 +21,6 @@ class MenuItemsTableSeeder extends Seeder
         \DB::table('menu_items')->insert(array (
             0 =>
             array (
-                'id' => 1,
                 'menu_id' => 1,
                 'title' => 'Dashboard',
                 'url' => '',
@@ -37,7 +36,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             1 =>
             array (
-                'id' => 2,
                 'menu_id' => 1,
                 'title' => 'Media',
                 'url' => '',
@@ -53,7 +51,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             2 =>
             array (
-                'id' => 3,
                 'menu_id' => 1,
                 'title' => 'Posts',
                 'url' => '',
@@ -69,7 +66,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             3 =>
             array (
-                'id' => 4,
                 'menu_id' => 1,
                 'title' => 'Users',
                 'url' => '',
@@ -85,7 +81,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             4 =>
             array (
-                'id' => 5,
                 'menu_id' => 1,
                 'title' => 'Categories',
                 'url' => '',
@@ -101,7 +96,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             5 =>
             array (
-                'id' => 6,
                 'menu_id' => 1,
                 'title' => 'Pages',
                 'url' => '',
@@ -117,7 +111,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             6 =>
             array (
-                'id' => 7,
                 'menu_id' => 1,
                 'title' => 'Roles',
                 'url' => '',
@@ -133,7 +126,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             7 =>
             array (
-                'id' => 8,
                 'menu_id' => 1,
                 'title' => 'Tools',
                 'url' => '',
@@ -149,7 +141,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             8 =>
             array (
-                'id' => 9,
                 'menu_id' => 1,
                 'title' => 'Menu Builder',
                 'url' => '',
@@ -165,7 +156,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             9 =>
             array (
-                'id' => 10,
                 'menu_id' => 1,
                 'title' => 'Database',
                 'url' => '',
@@ -181,7 +171,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             10 =>
             array (
-                'id' => 11,
                 'menu_id' => 1,
                 'title' => 'Compass',
                 'url' => '/admin/compass',
@@ -197,7 +186,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             11 =>
             array (
-                'id' => 12,
                 'menu_id' => 1,
                 'title' => 'Hooks',
                 'url' => '/admin/hooks',
@@ -213,7 +201,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             12 =>
             array (
-                'id' => 13,
                 'menu_id' => 1,
                 'title' => 'Settings',
                 'url' => '',
@@ -229,7 +216,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             13 =>
             array (
-                'id' => 14,
                 'menu_id' => 1,
                 'title' => 'Themes',
                 'url' => '/admin/themes',
@@ -245,7 +231,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             14 =>
             array (
-                'id' => 15,
                 'menu_id' => 2,
                 'title' => 'Dashboard',
                 'url' => '',
@@ -261,7 +246,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             15 =>
             array (
-                'id' => 16,
                 'menu_id' => 2,
                 'title' => 'Resources',
                 'url' => '#_',
@@ -277,7 +261,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             16 =>
             array (
-                'id' => 19,
                 'menu_id' => 2,
                 'title' => 'Next Child',
                 'url' => '/next',
@@ -293,7 +276,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             17 =>
             array (
-                'id' => 20,
                 'menu_id' => 2,
                 'title' => 'Next Child 2',
                 'url' => '/next',
@@ -309,7 +291,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             18 =>
             array (
-                'id' => 21,
                 'menu_id' => 2,
                 'title' => 'Documentation',
                 'url' => '/docs',
@@ -325,7 +306,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             19 =>
             array (
-                'id' => 22,
                 'menu_id' => 2,
                 'title' => 'Videos',
                 'url' => 'https://devdojo.com/series/wave',
@@ -341,7 +321,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             20 =>
             array (
-                'id' => 23,
                 'menu_id' => 2,
                 'title' => 'Support',
                 'url' => 'https://devdojo.com/forums/category/wave',
@@ -357,7 +336,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             21 =>
             array (
-                'id' => 25,
                 'menu_id' => 2,
                 'title' => 'Blog',
                 'url' => '/blog',
@@ -373,7 +351,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             22 =>
             array (
-                'id' => 26,
                 'menu_id' => 3,
                 'title' => 'Home',
                 'url' => '/#',
@@ -389,7 +366,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             23 =>
             array (
-                'id' => 27,
                 'menu_id' => 3,
                 'title' => 'Features',
                 'url' => '/#features',
@@ -405,7 +381,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             24 =>
             array (
-                'id' => 28,
                 'menu_id' => 3,
                 'title' => 'Testimonials',
                 'url' => '/#testimonials',
@@ -421,7 +396,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             25 =>
             array (
-                'id' => 29,
                 'menu_id' => 3,
                 'title' => 'Pricing',
                 'url' => '/#pricing',
@@ -437,7 +411,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             26 =>
             array (
-                'id' => 30,
                 'menu_id' => 1,
                 'title' => 'Announcements',
                 'url' => '/admin/announcements',
@@ -453,7 +426,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             27 =>
             array (
-                'id' => 31,
                 'menu_id' => 1,
                 'title' => 'BREAD',
                 'url' => '',
@@ -469,7 +441,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             28 =>
             array (
-                'id' => 32,
                 'menu_id' => 1,
                 'title' => 'Plans',
                 'url' => '',
@@ -485,7 +456,6 @@ class MenuItemsTableSeeder extends Seeder
             ),
             29 =>
             array (
-                'id' => 33,
                 'menu_id' => 3,
                 'title' => 'Blog',
                 'url' => '',

--- a/database/seeders/MenusTableSeeder.php
+++ b/database/seeders/MenusTableSeeder.php
@@ -21,21 +21,18 @@ class MenusTableSeeder extends Seeder
         \DB::table('menus')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'name' => 'admin',
                 'created_at' => '2017-11-21 16:23:22',
                 'updated_at' => '2017-11-21 16:23:22',
             ),
             1 => 
             array (
-                'id' => 2,
                 'name' => 'authenticated-menu',
                 'created_at' => '2017-11-28 14:47:49',
                 'updated_at' => '2018-04-13 22:25:28',
             ),
             2 => 
             array (
-                'id' => 3,
                 'name' => 'guest-menu',
                 'created_at' => '2018-04-13 22:25:37',
                 'updated_at' => '2018-04-13 22:25:37',

--- a/database/seeders/PagesTableSeeder.php
+++ b/database/seeders/PagesTableSeeder.php
@@ -21,7 +21,6 @@ class PagesTableSeeder extends Seeder
         \DB::table('pages')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'author_id' => 1,
                 'title' => 'Hello World',
                 'excerpt' => 'Hang the jib grog grog blossom grapple dance the hempen jig gangway pressgang bilge rat to go on account lugger. Nelsons folly gabion line draught scallywag fire ship gaff fluke fathom case shot. Sea Legs bilge rat sloop matey gabion long clothes run a shot across the bow Gold Road cog league.',
@@ -37,7 +36,6 @@ class PagesTableSeeder extends Seeder
             ),
             1 => 
             array (
-                'id' => 2,
                 'author_id' => 1,
                 'title' => 'About',
                 'excerpt' => 'This is the about page.',

--- a/database/seeders/PermissionsTableSeeder.php
+++ b/database/seeders/PermissionsTableSeeder.php
@@ -21,7 +21,6 @@ class PermissionsTableSeeder extends Seeder
         \DB::table('permissions')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'key' => 'browse_admin',
                 'table_name' => NULL,
                 'created_at' => '2018-06-22 20:15:45',
@@ -30,7 +29,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             1 => 
             array (
-                'id' => 2,
                 'key' => 'browse_bread',
                 'table_name' => NULL,
                 'created_at' => '2018-06-22 20:15:45',
@@ -39,7 +37,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             2 => 
             array (
-                'id' => 3,
                 'key' => 'browse_database',
                 'table_name' => NULL,
                 'created_at' => '2018-06-22 20:15:45',
@@ -48,7 +45,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             3 => 
             array (
-                'id' => 4,
                 'key' => 'browse_media',
                 'table_name' => NULL,
                 'created_at' => '2018-06-22 20:15:45',
@@ -57,7 +53,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             4 => 
             array (
-                'id' => 5,
                 'key' => 'browse_compass',
                 'table_name' => NULL,
                 'created_at' => '2018-06-22 20:15:45',
@@ -66,7 +61,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             5 => 
             array (
-                'id' => 6,
                 'key' => 'browse_menus',
                 'table_name' => 'menus',
                 'created_at' => '2018-06-22 20:15:45',
@@ -75,7 +69,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             6 => 
             array (
-                'id' => 7,
                 'key' => 'read_menus',
                 'table_name' => 'menus',
                 'created_at' => '2018-06-22 20:15:45',
@@ -84,7 +77,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             7 => 
             array (
-                'id' => 8,
                 'key' => 'edit_menus',
                 'table_name' => 'menus',
                 'created_at' => '2018-06-22 20:15:45',
@@ -93,7 +85,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             8 => 
             array (
-                'id' => 9,
                 'key' => 'add_menus',
                 'table_name' => 'menus',
                 'created_at' => '2018-06-22 20:15:45',
@@ -102,7 +93,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             9 => 
             array (
-                'id' => 10,
                 'key' => 'delete_menus',
                 'table_name' => 'menus',
                 'created_at' => '2018-06-22 20:15:45',
@@ -111,7 +101,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             10 => 
             array (
-                'id' => 11,
                 'key' => 'browse_roles',
                 'table_name' => 'roles',
                 'created_at' => '2018-06-22 20:15:45',
@@ -120,7 +109,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             11 => 
             array (
-                'id' => 12,
                 'key' => 'read_roles',
                 'table_name' => 'roles',
                 'created_at' => '2018-06-22 20:15:45',
@@ -129,7 +117,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             12 => 
             array (
-                'id' => 13,
                 'key' => 'edit_roles',
                 'table_name' => 'roles',
                 'created_at' => '2018-06-22 20:15:45',
@@ -138,7 +125,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             13 => 
             array (
-                'id' => 14,
                 'key' => 'add_roles',
                 'table_name' => 'roles',
                 'created_at' => '2018-06-22 20:15:45',
@@ -147,7 +133,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             14 => 
             array (
-                'id' => 15,
                 'key' => 'delete_roles',
                 'table_name' => 'roles',
                 'created_at' => '2018-06-22 20:15:45',
@@ -156,7 +141,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             15 => 
             array (
-                'id' => 16,
                 'key' => 'browse_users',
                 'table_name' => 'users',
                 'created_at' => '2018-06-22 20:15:45',
@@ -165,7 +149,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             16 => 
             array (
-                'id' => 17,
                 'key' => 'read_users',
                 'table_name' => 'users',
                 'created_at' => '2018-06-22 20:15:45',
@@ -174,7 +157,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             17 => 
             array (
-                'id' => 18,
                 'key' => 'edit_users',
                 'table_name' => 'users',
                 'created_at' => '2018-06-22 20:15:45',
@@ -183,7 +165,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             18 => 
             array (
-                'id' => 19,
                 'key' => 'add_users',
                 'table_name' => 'users',
                 'created_at' => '2018-06-22 20:15:45',
@@ -192,7 +173,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             19 => 
             array (
-                'id' => 20,
                 'key' => 'delete_users',
                 'table_name' => 'users',
                 'created_at' => '2018-06-22 20:15:45',
@@ -201,7 +181,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             20 => 
             array (
-                'id' => 21,
                 'key' => 'browse_settings',
                 'table_name' => 'settings',
                 'created_at' => '2018-06-22 20:15:45',
@@ -210,7 +189,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             21 => 
             array (
-                'id' => 22,
                 'key' => 'read_settings',
                 'table_name' => 'settings',
                 'created_at' => '2018-06-22 20:15:45',
@@ -219,7 +197,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             22 => 
             array (
-                'id' => 23,
                 'key' => 'edit_settings',
                 'table_name' => 'settings',
                 'created_at' => '2018-06-22 20:15:45',
@@ -228,7 +205,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             23 => 
             array (
-                'id' => 24,
                 'key' => 'add_settings',
                 'table_name' => 'settings',
                 'created_at' => '2018-06-22 20:15:45',
@@ -237,7 +213,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             24 => 
             array (
-                'id' => 25,
                 'key' => 'delete_settings',
                 'table_name' => 'settings',
                 'created_at' => '2018-06-22 20:15:45',
@@ -246,7 +221,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             25 => 
             array (
-                'id' => 26,
                 'key' => 'browse_categories',
                 'table_name' => 'categories',
                 'created_at' => '2018-06-22 20:15:46',
@@ -255,7 +229,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             26 => 
             array (
-                'id' => 27,
                 'key' => 'read_categories',
                 'table_name' => 'categories',
                 'created_at' => '2018-06-22 20:15:46',
@@ -264,7 +237,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             27 => 
             array (
-                'id' => 28,
                 'key' => 'edit_categories',
                 'table_name' => 'categories',
                 'created_at' => '2018-06-22 20:15:46',
@@ -273,7 +245,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             28 => 
             array (
-                'id' => 29,
                 'key' => 'add_categories',
                 'table_name' => 'categories',
                 'created_at' => '2018-06-22 20:15:46',
@@ -282,7 +253,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             29 => 
             array (
-                'id' => 30,
                 'key' => 'delete_categories',
                 'table_name' => 'categories',
                 'created_at' => '2018-06-22 20:15:46',
@@ -291,7 +261,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             30 => 
             array (
-                'id' => 31,
                 'key' => 'browse_posts',
                 'table_name' => 'posts',
                 'created_at' => '2018-06-22 20:15:46',
@@ -300,7 +269,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             31 => 
             array (
-                'id' => 32,
                 'key' => 'read_posts',
                 'table_name' => 'posts',
                 'created_at' => '2018-06-22 20:15:46',
@@ -309,7 +277,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             32 => 
             array (
-                'id' => 33,
                 'key' => 'edit_posts',
                 'table_name' => 'posts',
                 'created_at' => '2018-06-22 20:15:46',
@@ -318,7 +285,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             33 => 
             array (
-                'id' => 34,
                 'key' => 'add_posts',
                 'table_name' => 'posts',
                 'created_at' => '2018-06-22 20:15:46',
@@ -327,7 +293,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             34 => 
             array (
-                'id' => 35,
                 'key' => 'delete_posts',
                 'table_name' => 'posts',
                 'created_at' => '2018-06-22 20:15:46',
@@ -336,7 +301,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             35 => 
             array (
-                'id' => 36,
                 'key' => 'browse_pages',
                 'table_name' => 'pages',
                 'created_at' => '2018-06-22 20:15:46',
@@ -345,7 +309,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             36 => 
             array (
-                'id' => 37,
                 'key' => 'read_pages',
                 'table_name' => 'pages',
                 'created_at' => '2018-06-22 20:15:46',
@@ -354,7 +317,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             37 => 
             array (
-                'id' => 38,
                 'key' => 'edit_pages',
                 'table_name' => 'pages',
                 'created_at' => '2018-06-22 20:15:46',
@@ -363,7 +325,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             38 => 
             array (
-                'id' => 39,
                 'key' => 'add_pages',
                 'table_name' => 'pages',
                 'created_at' => '2018-06-22 20:15:46',
@@ -372,7 +333,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             39 => 
             array (
-                'id' => 40,
                 'key' => 'delete_pages',
                 'table_name' => 'pages',
                 'created_at' => '2018-06-22 20:15:46',
@@ -381,7 +341,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             40 => 
             array (
-                'id' => 41,
                 'key' => 'browse_hooks',
                 'table_name' => NULL,
                 'created_at' => '2018-06-22 20:15:46',
@@ -390,7 +349,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             41 => 
             array (
-                'id' => 42,
                 'key' => 'browse_announcements',
                 'table_name' => 'announcements',
                 'created_at' => '2018-05-20 21:08:14',
@@ -399,7 +357,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             42 => 
             array (
-                'id' => 43,
                 'key' => 'read_announcements',
                 'table_name' => 'announcements',
                 'created_at' => '2018-05-20 21:08:14',
@@ -408,7 +365,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             43 => 
             array (
-                'id' => 44,
                 'key' => 'edit_announcements',
                 'table_name' => 'announcements',
                 'created_at' => '2018-05-20 21:08:14',
@@ -417,7 +373,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             44 => 
             array (
-                'id' => 45,
                 'key' => 'add_announcements',
                 'table_name' => 'announcements',
                 'created_at' => '2018-05-20 21:08:14',
@@ -426,7 +381,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             45 => 
             array (
-                'id' => 46,
                 'key' => 'delete_announcements',
                 'table_name' => 'announcements',
                 'created_at' => '2018-05-20 21:08:14',
@@ -435,7 +389,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             46 => 
             array (
-                'id' => 47,
                 'key' => 'browse_themes',
                 'table_name' => 'admin',
                 'created_at' => '2017-11-21 16:31:00',
@@ -444,7 +397,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             47 => 
             array (
-                'id' => 48,
                 'key' => 'browse_hooks',
                 'table_name' => 'hooks',
                 'created_at' => '2018-06-22 13:55:03',
@@ -453,7 +405,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             48 => 
             array (
-                'id' => 49,
                 'key' => 'read_hooks',
                 'table_name' => 'hooks',
                 'created_at' => '2018-06-22 13:55:03',
@@ -462,7 +413,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             49 => 
             array (
-                'id' => 50,
                 'key' => 'edit_hooks',
                 'table_name' => 'hooks',
                 'created_at' => '2018-06-22 13:55:03',
@@ -471,7 +421,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             50 => 
             array (
-                'id' => 51,
                 'key' => 'add_hooks',
                 'table_name' => 'hooks',
                 'created_at' => '2018-06-22 13:55:03',
@@ -480,7 +429,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             51 => 
             array (
-                'id' => 52,
                 'key' => 'delete_hooks',
                 'table_name' => 'hooks',
                 'created_at' => '2018-06-22 13:55:03',
@@ -489,7 +437,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             52 => 
             array (
-                'id' => 53,
                 'key' => 'browse_plans',
                 'table_name' => 'plans',
                 'created_at' => '2018-07-03 04:50:28',
@@ -498,7 +445,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             53 => 
             array (
-                'id' => 54,
                 'key' => 'read_plans',
                 'table_name' => 'plans',
                 'created_at' => '2018-07-03 04:50:28',
@@ -507,7 +453,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             54 => 
             array (
-                'id' => 55,
                 'key' => 'edit_plans',
                 'table_name' => 'plans',
                 'created_at' => '2018-07-03 04:50:28',
@@ -516,7 +461,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             55 => 
             array (
-                'id' => 56,
                 'key' => 'add_plans',
                 'table_name' => 'plans',
                 'created_at' => '2018-07-03 04:50:28',
@@ -525,7 +469,6 @@ class PermissionsTableSeeder extends Seeder
             ),
             56 => 
             array (
-                'id' => 57,
                 'key' => 'delete_plans',
                 'table_name' => 'plans',
                 'created_at' => '2018-07-03 04:50:28',

--- a/database/seeders/PlansTableSeeder.php
+++ b/database/seeders/PlansTableSeeder.php
@@ -21,7 +21,6 @@ class PlansTableSeeder extends Seeder
         \DB::table('plans')->insert(array (
             0 =>
             array (
-                'id' => 1,
                 'name' => 'Basic',
                 'slug' => 'basic',
                 'description' => 'Signup for the Basic User Plan to access all the basic features.',
@@ -36,7 +35,6 @@ class PlansTableSeeder extends Seeder
             ),
             1 =>
             array (
-                'id' => 2,
                 'name' => 'Premium',
                 'slug' => 'premium',
                 'description' => 'Signup for our premium plan to access all our Premium Features.',
@@ -51,7 +49,6 @@ class PlansTableSeeder extends Seeder
             ),
             2 =>
             array (
-                'id' => 3,
                 'name' => 'Pro',
                 'slug' => 'pro',
                 'description' => 'Gain access to our pro features with the pro plan.',

--- a/database/seeders/PostsTableSeeder.php
+++ b/database/seeders/PostsTableSeeder.php
@@ -21,7 +21,6 @@ class PostsTableSeeder extends Seeder
         \DB::table('posts')->insert(array (
             0 =>
             array (
-                'id' => 5,
                 'author_id' => 1,
                 'category_id' => 1,
                 'title' => 'Best ways to market your application',
@@ -57,7 +56,6 @@ class PostsTableSeeder extends Seeder
             ),
             1 =>
             array (
-                'id' => 6,
                 'author_id' => 1,
                 'category_id' => 1,
                 'title' => 'Achieving your Dreams',
@@ -93,7 +91,6 @@ class PostsTableSeeder extends Seeder
             ),
             2 =>
             array (
-                'id' => 7,
                 'author_id' => 1,
                 'category_id' => 1,
                 'title' => 'Building a solid foundation',
@@ -129,7 +126,6 @@ class PostsTableSeeder extends Seeder
             ),
             3 =>
             array (
-                'id' => 8,
                 'author_id' => 1,
                 'category_id' => 2,
                 'title' => 'Finding the solution that fits for you',
@@ -165,7 +161,6 @@ class PostsTableSeeder extends Seeder
             ),
             4 =>
             array (
-                'id' => 9,
                 'author_id' => 1,
                 'category_id' => 2,
                 'title' => 'Creating something useful',
@@ -201,7 +196,6 @@ class PostsTableSeeder extends Seeder
             ),
             5 =>
             array (
-                'id' => 10,
                 'author_id' => 1,
                 'category_id' => 1,
                 'title' => 'Never Stop Creating',

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -21,7 +21,6 @@ class RolesTableSeeder extends Seeder
         \DB::table('roles')->insert(array (
             0 =>
             array (
-                'id' => 1,
                 'name' => 'admin',
                 'display_name' => 'Admin User',
                 'created_at' => '2017-11-21 16:23:22',
@@ -29,7 +28,6 @@ class RolesTableSeeder extends Seeder
             ),
             1 =>
             array (
-                'id' => 2,
                 'name' => 'trial',
                 'display_name' => 'Free Trial',
                 'created_at' => '2017-11-21 16:23:22',
@@ -37,7 +35,6 @@ class RolesTableSeeder extends Seeder
             ),
             2 =>
             array (
-                'id' => 3,
                 'name' => 'basic',
                 'display_name' => 'Basic Plan',
                 'created_at' => '2018-07-03 05:03:21',
@@ -45,7 +42,6 @@ class RolesTableSeeder extends Seeder
             ),
             3 =>
             array (
-                'id' => 4,
                 'name' => 'pro',
                 'display_name' => 'Pro Plan',
                 'created_at' => '2018-07-03 16:27:16',
@@ -53,7 +49,6 @@ class RolesTableSeeder extends Seeder
             ),
             4 =>
             array (
-                'id' => 5,
                 'name' => 'premium',
                 'display_name' => 'Premium Plan',
                 'created_at' => '2018-07-03 16:28:42',
@@ -61,7 +56,6 @@ class RolesTableSeeder extends Seeder
             ),
             5 =>
             array (
-                'id' => 6,
                 'name' => 'cancelled',
                 'display_name' => 'Cancelled User',
                 'created_at' => '2018-07-03 16:28:42',

--- a/database/seeders/SettingsTableSeeder.php
+++ b/database/seeders/SettingsTableSeeder.php
@@ -21,7 +21,6 @@ class SettingsTableSeeder extends Seeder
         \DB::table('settings')->insert(array (
             0 =>
             array (
-                'id' => 1,
                 'key' => 'site.title',
                 'display_name' => 'Site Title',
                 'value' => 'Wave',
@@ -32,7 +31,6 @@ class SettingsTableSeeder extends Seeder
             ),
             1 =>
             array (
-                'id' => 2,
                 'key' => 'site.description',
                 'display_name' => 'Site Description',
                 'value' => 'The Software as a Service Starter Kit built on Laravel & Voyager',
@@ -43,7 +41,6 @@ class SettingsTableSeeder extends Seeder
             ),
             2 =>
             array (
-                'id' => 4,
                 'key' => 'site.google_analytics_tracking_id',
                 'display_name' => 'Google Analytics Tracking ID',
                 'value' => NULL,
@@ -54,7 +51,6 @@ class SettingsTableSeeder extends Seeder
             ),
             3 =>
             array (
-                'id' => 6,
                 'key' => 'admin.title',
                 'display_name' => 'Admin Title',
                 'value' => 'Wave',
@@ -65,7 +61,6 @@ class SettingsTableSeeder extends Seeder
             ),
             4 =>
             array (
-                'id' => 7,
                 'key' => 'admin.description',
                 'display_name' => 'Admin Description',
                 'value' => 'Create some waves and build your next great idea',
@@ -76,7 +71,6 @@ class SettingsTableSeeder extends Seeder
             ),
             5 =>
             array (
-                'id' => 8,
                 'key' => 'admin.loader',
                 'display_name' => 'Admin Loader',
                 'value' => '',
@@ -87,7 +81,6 @@ class SettingsTableSeeder extends Seeder
             ),
             6 =>
             array (
-                'id' => 9,
                 'key' => 'admin.icon_image',
                 'display_name' => 'Admin Icon Image',
                 'value' => '',
@@ -98,7 +91,6 @@ class SettingsTableSeeder extends Seeder
             ),
             7 =>
             array (
-                'id' => 10,
                 'key' => 'admin.google_analytics_client_id',
             'display_name' => 'Google Analytics Client ID (used for admin dashboard)',
                 'value' => '',
@@ -109,7 +101,6 @@ class SettingsTableSeeder extends Seeder
             ),
             8 =>
             array (
-                'id' => 11,
                 'key' => 'site.favicon',
                 'display_name' => 'Favicon',
                 'value' => '',
@@ -120,7 +111,6 @@ class SettingsTableSeeder extends Seeder
             ),
             9 =>
             array (
-                'id' => 12,
                 'key' => 'auth.dashboard_redirect',
                 'display_name' => 'Homepage Redirect to Dashboard if Logged in',
                 'value' => '0',
@@ -131,7 +121,6 @@ class SettingsTableSeeder extends Seeder
             ),
             10 =>
             array (
-                'id' => 13,
                 'key' => 'auth.email_or_username',
                 'display_name' => 'Users Login with Email or Username',
                 'value' => 'email',
@@ -148,7 +137,6 @@ class SettingsTableSeeder extends Seeder
             ),
             11 =>
             array (
-                'id' => 14,
                 'key' => 'auth.username_in_registration',
                 'display_name' => 'Username when Registering',
                 'value' => 'yes',
@@ -165,7 +153,6 @@ class SettingsTableSeeder extends Seeder
             ),
             12 =>
             array (
-                'id' => 15,
                 'key' => 'auth.verify_email',
                 'display_name' => 'Verify Email during Sign Up',
                 'value' => '0',
@@ -176,7 +163,6 @@ class SettingsTableSeeder extends Seeder
             ),
             13 =>
             array (
-                'id' => 16,
                 'key' => 'billing.card_upfront',
                 'display_name' => 'Require Credit Card Up Front',
                 'value' => '1',
@@ -191,7 +177,6 @@ class SettingsTableSeeder extends Seeder
             ),
             14 =>
             array (
-                'id' => 17,
                 'key' => 'billing.trial_days',
                 'display_name' => 'Trial Days when No Credit Card Up Front',
                 'value' => '-1',

--- a/database/seeders/TranslationsTableSeeder.php
+++ b/database/seeders/TranslationsTableSeeder.php
@@ -21,7 +21,6 @@ class TranslationsTableSeeder extends Seeder
         \DB::table('translations')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_singular',
                 'foreign_key' => 1,
@@ -32,7 +31,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             1 => 
             array (
-                'id' => 2,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_singular',
                 'foreign_key' => 2,
@@ -43,7 +41,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             2 => 
             array (
-                'id' => 3,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_singular',
                 'foreign_key' => 3,
@@ -54,7 +51,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             3 => 
             array (
-                'id' => 4,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_singular',
                 'foreign_key' => 4,
@@ -65,7 +61,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             4 => 
             array (
-                'id' => 5,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_singular',
                 'foreign_key' => 5,
@@ -76,7 +71,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             5 => 
             array (
-                'id' => 6,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_singular',
                 'foreign_key' => 6,
@@ -87,7 +81,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             6 => 
             array (
-                'id' => 7,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_plural',
                 'foreign_key' => 1,
@@ -98,7 +91,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             7 => 
             array (
-                'id' => 8,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_plural',
                 'foreign_key' => 2,
@@ -109,7 +101,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             8 => 
             array (
-                'id' => 9,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_plural',
                 'foreign_key' => 3,
@@ -120,7 +111,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             9 => 
             array (
-                'id' => 10,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_plural',
                 'foreign_key' => 4,
@@ -131,7 +121,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             10 => 
             array (
-                'id' => 11,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_plural',
                 'foreign_key' => 5,
@@ -142,7 +131,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             11 => 
             array (
-                'id' => 12,
                 'table_name' => 'data_types',
                 'column_name' => 'display_name_plural',
                 'foreign_key' => 6,
@@ -153,7 +141,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             12 => 
             array (
-                'id' => 13,
                 'table_name' => 'categories',
                 'column_name' => 'slug',
                 'foreign_key' => 1,
@@ -164,7 +151,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             13 => 
             array (
-                'id' => 14,
                 'table_name' => 'categories',
                 'column_name' => 'name',
                 'foreign_key' => 1,
@@ -175,7 +161,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             14 => 
             array (
-                'id' => 15,
                 'table_name' => 'categories',
                 'column_name' => 'slug',
                 'foreign_key' => 2,
@@ -186,7 +171,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             15 => 
             array (
-                'id' => 16,
                 'table_name' => 'categories',
                 'column_name' => 'name',
                 'foreign_key' => 2,
@@ -197,7 +181,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             16 => 
             array (
-                'id' => 17,
                 'table_name' => 'pages',
                 'column_name' => 'title',
                 'foreign_key' => 1,
@@ -208,7 +191,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             17 => 
             array (
-                'id' => 18,
                 'table_name' => 'pages',
                 'column_name' => 'slug',
                 'foreign_key' => 1,
@@ -219,7 +201,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             18 => 
             array (
-                'id' => 19,
                 'table_name' => 'pages',
                 'column_name' => 'body',
                 'foreign_key' => 1,
@@ -231,7 +212,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             19 => 
             array (
-                'id' => 20,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 1,
@@ -242,7 +222,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             20 => 
             array (
-                'id' => 21,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 2,
@@ -253,7 +232,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             21 => 
             array (
-                'id' => 22,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 3,
@@ -264,7 +242,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             22 => 
             array (
-                'id' => 23,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 4,
@@ -275,7 +252,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             23 => 
             array (
-                'id' => 24,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 5,
@@ -286,7 +262,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             24 => 
             array (
-                'id' => 25,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 6,
@@ -297,7 +272,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             25 => 
             array (
-                'id' => 26,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 7,
@@ -308,7 +282,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             26 => 
             array (
-                'id' => 27,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 8,
@@ -319,7 +292,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             27 => 
             array (
-                'id' => 28,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 9,
@@ -330,7 +302,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             28 => 
             array (
-                'id' => 29,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 10,
@@ -341,7 +312,6 @@ class TranslationsTableSeeder extends Seeder
             ),
             29 => 
             array (
-                'id' => 30,
                 'table_name' => 'menu_items',
                 'column_name' => 'title',
                 'foreign_key' => 13,

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -21,7 +21,6 @@ class UsersTableSeeder extends Seeder
         \DB::table('users')->insert(array (
             0 => 
             array (
-                'id' => 1,
                 'role_id' => 1,
                 'name' => 'Wave Admin',
                 'email' => 'admin@admin.com',

--- a/database/seeders/VoyagerThemeOptionsTableSeeder.php
+++ b/database/seeders/VoyagerThemeOptionsTableSeeder.php
@@ -21,7 +21,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
         \DB::table('theme_options')->insert(array (
             0 =>
             array (
-                'id' => 17,
                 'theme_id' => 1,
                 'key' => 'logo',
                 'value' => '',
@@ -30,7 +29,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             1 =>
             array(
-                'id' => 18,
                 'theme_id' => 1,
                 'key' => 'home_headline',
                 'value' => 'Welcome to Wave',
@@ -39,7 +37,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             2 =>
             array(
-                'id' => 19,
                 'theme_id' => 1,
                 'key' => 'home_subheadline',
                 'value' => 'Start crafting your next great idea.',
@@ -48,7 +45,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             3 =>
             array(
-                'id' => 20,
                 'theme_id' => 1,
                 'key' => 'home_description',
                 'value' => 'Wave will help you rapidly build a Software as a Service. Out of the box Authentication, Subscriptions, Invoices, Announcements, User Profiles, API, and so much more!',
@@ -57,7 +53,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             4 =>
             array(
-                'id' => 21,
                 'theme_id' => 1,
                 'key' => 'home_cta',
                 'value' => 'Signup',
@@ -66,7 +61,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             5 =>
             array(
-                'id' => 22,
                 'theme_id' => 1,
                 'key' => 'home_cta_url',
                 'value' => '/register',
@@ -75,7 +69,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             6 =>
             array(
-                'id' => 23,
                 'theme_id' => 1,
                 'key' => 'home_promo_image',
                 'value' => 'themes/February2018/mFajn4fwpGFXzI1UsNH6.png',
@@ -84,7 +77,6 @@ class VoyagerThemeOptionsTableSeeder extends Seeder
             ),
             7 =>
             array(
-                'id' => 24,
                 'theme_id' => 1,
                 'key' => 'footer_logo',
                 'value' => 'themes/August2018/TksmVWMqp5JXUQj8C6Ct.png',

--- a/database/seeders/VoyagerThemesTableSeeder.php
+++ b/database/seeders/VoyagerThemesTableSeeder.php
@@ -21,7 +21,6 @@ class VoyagerThemesTableSeeder extends Seeder
         \DB::table('themes')->insert(array (
             0 =>
             array (
-                'id' => 1,
                 'name' => 'Tailwind Theme',
                 'folder' => 'tailwind',
                 'active' => 1,

--- a/database/seeders/WaveKeyValuesTableSeeder.php
+++ b/database/seeders/WaveKeyValuesTableSeeder.php
@@ -21,7 +21,6 @@ class WaveKeyValuesTableSeeder extends Seeder
         \DB::table('wave_key_values')->insert(array (
             0 =>
             array (
-                'id' => 10,
                 'type' => 'text_area',
                 'keyvalue_id' => 1,
                 'keyvalue_type' => 'users',


### PR DESCRIPTION
Fixes the following error:

```
[2021-05-27 18:25:07] local.ERROR: SQLSTATE[23505]: **Unique violation: 7 ERROR:  duplicate key value violates unique constraint "menus_pkey"**
DETAIL:  Key (id)=(3) already exists. (SQL: insert into "menus" ("name", "updated_at", "created_at") values (sidebar, 2021-05-27 18:25:07, 2021-05-27 18:25:07) returning "id") {"userId":1,"exception":"[object] (Illuminate\\Database\\QueryException(code: 23505): SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint \"menus_pkey\"
```

Only affecting PostgreSQL.

Seems like when you explicitly assign a value to the incrementing column PostgreSQL does not register this in the next sequence causing the ` duplicate key value violates unique constraint` error. By leaving it out, everything works properly.

