### PR TITLE
Fix paddle checkout (js) always in sandbox mode

### DIFF
--- a/wave/resources/views/checkout.blade.php
+++ b/wave/resources/views/checkout.blade.php
@@ -4,8 +4,11 @@
     window.vendor_id = parseInt('{{ config("wave.paddle.vendor") }}');
 
     if(vendor_id){
-        Paddle.Environment.set('sandbox');
         Paddle.Setup({ vendor: vendor_id });
+    }
+
+    if("{{ config('wave.paddle.env') }}" == 'sandbox') {
+        Paddle.Environment.set('sandbox');
     }
 
     let checkoutBtns = document.getElementsByClassName("checkout");


### PR DESCRIPTION
Hey there, the paddle checkout view it's always in sandbox mode, it has to take a look at the config.