### PR TITLE
Remove spatie/laravel-ray package by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "laravel/helpers": "^1.0",
         "laravel/tinker": "^2.0",
         "livewire/livewire": "^2.4",
-        "spatie/laravel-ray": "^1.17",
         "tcg/voyager": "1.4.x-dev",
         "tymon/jwt-auth": "dev-develop"
     },


### PR DESCRIPTION
Hey there, most of us we don't have this package, so this PR is to remove this by default.

Also, this package cause me thousands of errors per minute in my laravel.log:
![image](https://user-images.githubusercontent.com/6561770/125936655-fbd7f526-1bb3-4371-b45e-5a5e8016215a.png)
