### PR TITLE
Fix logout route name already registered on optimize command

### DIFF
--- a/resources/views/themes/tailwind/menus/authenticated.blade.php
+++ b/resources/views/themes/tailwind/menus/authenticated.blade.php
@@ -109,7 +109,7 @@
                     </div>
                     <div class="border-t border-gray-100"></div>
                     <div class="py-1">
-                        <a href="{{ route('logout') }}" class="block w-full px-4 py-2 text-sm leading-5 text-left text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">
+                        <a href="{{ route('wave.logout') }}" class="block w-full px-4 py-2 text-sm leading-5 text-left text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">
                             Sign out
                         </a>
                     </div>

--- a/wave/routes/web.php
+++ b/wave/routes/web.php
@@ -9,7 +9,7 @@ Route::get('@{username}', '\Wave\Http\Controllers\ProfileController@index')->nam
 Route::view('docs/{page?}', 'docs::index')->where('page', '(.*)');
 
 // Additional Auth Routes
-Route::get('logout', 'Auth\LoginController@logout')->name('logout');
+Route::get('logout', 'Auth\LoginController@logout')->name('wave.logout');
 Route::get('user/verify/{verification_code}', 'Auth\RegisterController@verify')->name('verify');
 Route::post('register/complete', '\Wave\Http\Controllers\Auth\RegisterController@complete')->name('wave.register-complete');
 


### PR DESCRIPTION
<img width="650" alt="Screenshot 2021-07-17 194456" src="https://user-images.githubusercontent.com/26044984/126043981-47dc048f-31d6-4c92-b3e3-8538b3ccf15c.png">

Unable to prepare route [logout] for serialization. Another route has already been assigned name [logout].