### PR TITLE
Fix SQLSTATE[HY000] [2002] Connection refused during artisan package:discover

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,8 +17,7 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->environment() == 'production') {
             $this->app['request']->server->set('HTTPS', true);
         }
-        // rad man
-        Schema::defaultStringLength(191);
+        $this->setSchemaDefaultLength();
     }
 
     /**
@@ -29,5 +28,13 @@ class AppServiceProvider extends ServiceProvider
     public function register()
     {
 
+    }
+
+    private function setSchemaDefaultLength(): void
+    {
+        try {
+            Schema::defaultStringLength(191);
+        }
+        catch (\Exception $exception){}
     }
 }


### PR DESCRIPTION
If a user installs composer dependencies before configuring the database environment, the composer post-install script `php artisan package:discover` fails with a `Doctrine\DBAL\Driver\PDO\Exception` as per the screenshot below.

<img width="876" alt="image" src="https://user-images.githubusercontent.com/1807304/136383739-767a60c8-19d1-40ba-85e0-c06cfae103e2.png">

I appreciate that the documentation is deliberate in asking the user to set the `.env` variables before running `composer install` but I think generally, `package:discovery` and composer installation should be independent of database connection.

Kudos for an amazing package as always