### PR TITLE
Fix provider properties causing errors

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        'App\Model' => 'App\Policies\ModelPolicy',
+        // 'App\Model' => 'App\Policies\ModelPolicy',
     ];
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -13,9 +13,9 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'App\Events\Event' => [
-            'App\Listeners\EventListener',
-        ],
+        // 'App\Events\Event' => [
+        //     'App\Listeners\EventListener',
+        // ],
     ];
 
     /**


### PR DESCRIPTION
Noticed two providers had properties that were causing errors in the logs. This is mainly the [AuthServiceProvider](https://github.com/thedevdojo/wave/blob/HEAD/app/Providers/AuthServiceProvider.php#L16) since it's called on each incoming request when the application is booting up and setting up the Gates.

The [EventServiceProvider](https://github.com/thedevdojo/wave/blob/78bb3901d20d97842a3e46aae7a01b4c8c09eeec/app/Providers/EventServiceProvider.php#L16-L18) also has a listener mapping that doesn't exist. It doesn't cause an error so far as I've seen, but commented that one out as well just in case.

Now the logs won't be filled with useless errors anymore. 👍

### Screenshot of logs.

![Screen Shot 2021-11-13 at 9 31 09 PM](https://user-images.githubusercontent.com/2221746/141658694-56153c5b-de93-4aa0-95ae-5935cc2e5d40.png)