### PR TITLE
role-based-blade-directives

### DIFF
--- a/wave/src/WaveServiceProvider.php
+++ b/wave/src/WaveServiceProvider.php
@@ -148,6 +148,24 @@ class WaveServiceProvider extends ServiceProvider
             return '{!! view("wave::checkout")->render() !!}';
         });
 
+        // role Directives
+
+        Blade::directive('role', function ($role) {
+            return "<?php if (!auth()->guest() && auth()->user()->hasRole($role)) { ?>";
+        });
+
+        Blade::directive('notrole', function () {
+            return "<?php } else { ?>";
+        });
+
+
+        Blade::directive('endrole', function () {
+            return "<?php } ?>";
+        });
+
+
+
+
     }
 
     private function loadLivewireComponents(){


### PR DESCRIPTION
create this PR for having more blade directives in Wave with regard to user roles. It might have useful for SAAS with many user roles. an example like this;
"@role('role')
 {role based content } 
@endrole('role') 
and have the conditional rendering functionality of laravel with ease. 
(notrole does not seem logical but I kept the same structure with other blade direvtives of wave)