### PR TITLE
Fix plan switching updating role if Paddle returns error

### DIFF
--- a/wave/src/Http/Controllers/SubscriptionController.php
+++ b/wave/src/Http/Controllers/SubscriptionController.php
@@ -189,22 +189,30 @@ class SubscriptionController extends Controller
         $plan = Plan::where('plan_id', $request->plan_id)->first();
 
         if(isset($plan->id)){
-
-
             // Update the user plan with Paddle
             $response = Http::post($this->paddle_vendors_url . '/2.0/subscription/users/update', [
                 'vendor_id' => $this->vendor_id,
                 'vendor_auth_code' => $this->vendor_auth_code,
-                'subscription_id' => auth()->user()->subscription->subscription_id,
+                'subscription_id' => $request->user()->subscription->subscription_id,
                 'plan_id' => $request->plan_id
             ]);
 
-            // Next, update the user role associated with the updated plan
-            auth()->user()->role_id = $plan->role_id;
-            auth()->user()->save();
-
             if($response->successful()){
-                return back()->with(['message' => 'Successfully switched to the ' . $plan->name . ' plan.', 'message_type' => 'success']);
+                $body = $response->json();
+
+                if($body['success']){
+                    // Next, update the user role associated with the updated plan
+                    $request->user()->forceFill([
+                        'role_id' => $plan->role_id
+                    ])->save();
+
+                    // And, update the subscription with the updated plan.
+                    $request->user()->subscription()->update([
+                        'plan_id' => $request->plan_id
+                    ]);
+
+                    return back()->with(['message' => 'Successfully switched to the ' . $plan->name . ' plan.', 'message_type' => 'success']);
+                }
             }
 
         }


### PR DESCRIPTION
Found an issue with the subscription plan switching on my Laravel 9 fork and decided to backport it here. The issue happens if the API call to Paddle happens to return an error, for instance, the `plan_id` exists in the APP but doesn't on Paddle. Or say the Paddle API happens to be down. The subscription doesn't update on Paddle's system but the users' role still changes.

This PR fixes this issue by only updating the users' role if we get a successful response from the Paddle API. It also now updates the `plan_id` on the subscription model.