### PR TITLE
Fix OOM problem in install middleware

### DIFF
--- a/wave/src/Http/Middleware/InstallMiddleware.php
+++ b/wave/src/Http/Middleware/InstallMiddleware.php
@@ -18,7 +18,7 @@ class InstallMiddleware
     {
 
         // If there are no users in the database we need to run the install script
-        if(User::all()->count() < 1){
+        if(User::first() === null){
             if( $request->route()->getName() != 'wave.install' ){
                 return redirect()->route('wave.install');
             }


### PR DESCRIPTION
Fix the [OOM problem reported here](https://devdojo.com/question/i-got-28k-users-and-it-give-me-error-allowed-memory-size-of-134217728-bytes-exhausted) when there are +20k users.

Rather than getting `::all()` users, we can check if there is at least 1 user which should be more performant. 