### PR TITLE
Fix current password validation

### DIFF
--- a/wave/src/Http/Controllers/SettingsController.php
+++ b/wave/src/Http/Controllers/SettingsController.php
@@ -75,16 +75,12 @@ class SettingsController extends Controller
     public function securityPut(Request $request){
 
         $validator = Validator::make($request->all(), [
-            'current_password' => 'required',
+            'current_password' => 'required|current_password',
             'password' => 'required|confirmed|min:'.config('wave.auth.min_password_length'),
         ]);
 
         if ($validator->fails()) {
             return back()->with(['message' => $validator->errors()->first(), 'message_type' => 'danger']);
-        }
-
-        if (! Hash::check($request->current_password, $request->user()->password)) {
-            return back()->with(['message' => 'Incorrect current password entered.', 'message_type' => 'danger']);
         }
 
         auth()->user()->forceFill([

--- a/wave/src/Http/Livewire/Settings/Security.php
+++ b/wave/src/Http/Livewire/Settings/Security.php
@@ -13,7 +13,7 @@ class Security extends Component
     protected function rules()
     {
         return [
-            'current_password' => 'required',
+            'current_password' => 'required|current_password',
             'password' => 'required|confirmed|min:'.config('wave.auth.min_password_length')
         ];
     }


### PR DESCRIPTION
This PR fixes the current password validation for the Tallstack theme and others.

Laravel renamed[^1] the `password` rule in Laravel 9 to `current_password`[^2].

[^1]: https://laravel.com/docs/9.x/validation#rule-password
[^2]: https://laravel.com/docs/9.x/validation#rule-current-password