### PR TITLE
Change repo name strtolower

### DIFF
--- a/app/Http/Livewire/Wave/DeployToDo.php
+++ b/app/Http/Livewire/Wave/DeployToDo.php
@@ -56,6 +56,7 @@ class DeployToDo extends Component
             // repo must contain a '/', do a check for that
             $repoSplit = explode('/', $this->repo);
             $repoName = (isset($repoSplit[0]) && isset($repoSplit[1])) ? $repoSplit[0] . '-' . $repoSplit[1] : false;
+            $repoName = strtolower($repoName);
             if(!$repoName){
                 $this->dispatchBrowserEvent('notify', ['type' => 'error', 'message' => 'Please make sure you enter a valiid repo (ex: user/repo)']);
                 return;
@@ -74,7 +75,6 @@ class DeployToDo extends Component
             // replace values with repoName and Repo url
             $finalJSONPayload = json_encode($this->deploy);
             $finalJSONPayload = str_replace('${wave.name}', str_replace('_', '-', $repoName), $finalJSONPayload);
-            //dd($this->repo);
             $finalJSONPayload = str_replace('${wave.repo}', $this->repo, $finalJSONPayload);
 
             $response = Http::withToken($this->api_key)->withBody( $finalJSONPayload, 'application/json')


### PR DESCRIPTION
The DigitalOcean API will fail with the following if you have uppercase letters in your repository name:

```
"error validating app spec field "name": name in body should match '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'"
```
