### PR TITLE
Clean web and api routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+/storage/debugbar/*
 
 # Wave ignores.
 /public/.well-known

--- a/wave/docs/concepts/routing.md
+++ b/wave/docs/concepts/routing.md
@@ -11,82 +11,9 @@ In this section we'll quickly cover the Wave routes.
 <a name="web-routes"></a>
 ### Wave Web Routes
 
-If you take a look inside of `wave/routes/web.php` you will see all the Wave web routes:
+If you take a look inside of `wave/routes/web.php` you will be able to see all Wave web routes.
 
-```php
-<?php
-
-Route::impersonate();
-
-Route::get('/', '\Wave\Http\Controllers\HomeController@index')->name('wave.home');
-Route::get('@{username}', '\Wave\Http\Controllers\ProfileController@index')->name('wave.profile');
-
-// Documentation routes
-Route::view('docs/{page?}', 'docs::index')->where('page', '(.*)');
-
-// Additional Auth Routes
-Route::get('logout', 'Auth\LoginController@logout')->name('logout');
-Route::get('user/verify/{verification_code}', 'Auth\RegisterController@verify')->name('verify');
-Route::post('register/complete', '\Wave\Http\Controllers\Auth\RegisterController@complete')->name('wave.register-complete');
-
-Route::get('blog', '\Wave\Http\Controllers\BlogController@index')->name('wave.blog');
-Route::get('blog/{category}', '\Wave\Http\Controllers\BlogController@category')->name('wave.blog.category');
-Route::get('blog/{category}/{post}', '\Wave\Http\Controllers\BlogController@post')->name('wave.blog.post');
-
-Route::view('install', 'wave::install')->name('wave.install');
-
-/***** Pages *****/
-Route::get('p/{page}', '\Wave\Http\Controllers\PageController@page');
-
-/***** Pricing Page *****/
-Route::view('pricing', 'theme::pricing')->name('wave.pricing');
-
-/***** Billing Routes *****/
-Route::post('/billing/webhook', '\Wave\Http\Controllers\WebhookController@handleWebhook');
-Route::post('paddle/webhook', '\Wave\Http\Controllers\SubscriptionController@hook');
-Route::post('checkout', '\Wave\Http\Controllers\SubscriptionController@checkout')->name('checkout');
-
-Route::get('test', '\Wave\Http\Controllers\SubscriptionController@test');
-
-Route::group(['middleware' => 'wave'], function () {
-	Route::get('dashboard', '\Wave\Http\Controllers\DashboardController@index')->name('wave.dashboard');
-});
-
-Route::group(['middleware' => 'auth'], function(){
-	Route::get('settings/{section?}', '\Wave\Http\Controllers\SettingsController@index')->name('wave.settings');
-
-	Route::post('settings/profile', '\Wave\Http\Controllers\SettingsController@profilePut')->name('wave.settings.profile.put');
-	Route::put('settings/security', '\Wave\Http\Controllers\SettingsController@securityPut')->name('wave.settings.security.put');
-
-	Route::post('settings/api', '\Wave\Http\Controllers\SettingsController@apiPost')->name('wave.settings.api.post');
-	Route::put('settings/api/{id?}', '\Wave\Http\Controllers\SettingsController@apiPut')->name('wave.settings.api.put');
-	Route::delete('settings/api/{id?}', '\Wave\Http\Controllers\SettingsController@apiDelete')->name('wave.settings.api.delete');
-
-	Route::get('settings/invoices/{invoice}', '\Wave\Http\Controllers\SettingsController@invoice')->name('wave.invoice');
-
-	Route::get('notifications', '\Wave\Http\Controllers\NotificationController@index')->name('wave.notifications');
-	Route::get('announcements', '\Wave\Http\Controllers\AnnouncementController@index')->name('wave.announcements');
-	Route::get('announcement/{id}', '\Wave\Http\Controllers\AnnouncementController@announcement')->name('wave.announcement');
-	Route::post('announcements/read', '\Wave\Http\Controllers\AnnouncementController@read')->name('wave.announcements.read');
-	Route::get('notifications', '\Wave\Http\Controllers\NotificationController@index')->name('wave.notifications');
-	Route::post('notification/read/{id}', '\Wave\Http\Controllers\NotificationController@delete')->name('wave.notification.read');
-
-    /********** Checkout/Billing Routes ***********/
-    Route::post('cancel', '\Wave\Http\Controllers\SubscriptionController@cancel')->name('wave.cancel');
-    Route::view('checkout/welcome', 'theme::welcome');
-
-    Route::post('subscribe', '\Wave\Http\Controllers\SubscriptionController@subscribe')->name('wave.subscribe');
-	Route::view('trial_over', 'theme::trial_over')->name('wave.trial_over');
-	Route::view('cancelled', 'theme::cancelled')->name('wave.cancelled');
-    Route::post('switch-plans', '\Wave\Http\Controllers\SubscriptionController@switchPlans')->name('wave.switch-plans');
-});
-
-Route::group(['middleware' => 'admin.user'], function(){
-    Route::view('admin/do', 'wave::do');
-});
-```
-
-Next, if you take a look inside of your `routes/web.php`, you will see the following line:
+Next, if you take a look inside your `routes/web.php`, you will see the following line:
 
 ```php
 // Include Wave Routes

--- a/wave/resources/views/install.blade.php
+++ b/wave/resources/views/install.blade.php
@@ -1,63 +1,89 @@
-@if(\Wave\User::all()->count() < 1)
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wave Installation</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.4/tailwind.min.css">
+</head>
+<body class="bg-gray-50">
 
+<div class="flex flex-col items-center justify-center w-screen h-screen">
+    <svg class="w-20 h-20 -mt-12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 206">
+        <defs/>
+        <defs>
+            <linearGradient id="a" x1="100%" x2="0%" y1="45.596%" y2="45.596%">
+                <stop offset="0%" stop-color="#5D63FB"/>
+                <stop offset="100%" stop-color="#0769FF"/>
+            </linearGradient>
+            <linearGradient id="b" x1="50%" x2="50%" y1="0%" y2="100%">
+                <stop offset="0%" stop-color="#39BEFF"/>
+                <stop offset="100%" stop-color="#0769FF"/>
+            </linearGradient>
+            <linearGradient id="c" x1="0%" x2="99.521%" y1="50%" y2="50%">
+                <stop offset="0%" stop-color="#38BCFF"/>
+                <stop offset="99.931%" stop-color="#91D8FF"/>
+            </linearGradient>
+        </defs>
+        <g fill="none" fill-rule="evenodd">
+            <path fill="url(#a)"
+                  d="M185.302 38c14.734 18.317 22.742 41.087 22.698 64.545C208 159.68 161.43 206 103.986 206c-39.959-.01-76.38-22.79-93.702-58.605C-7.04 111.58-2.203 69.061 22.727 38a104.657 104.657 0 00-9.283 43.352c0 54.239 40.55 98.206 90.57 98.206 50.021 0 90.571-43.973 90.571-98.206A104.657 104.657 0 00185.302 38z"/>
+            <path fill="url(#b)"
+                  d="M105.11 0A84.144 84.144 0 01152 14.21C119.312-.651 80.806 8.94 58.7 37.45c-22.105 28.51-22.105 68.58 0 97.09 22.106 28.51 60.612 38.101 93.3 23.239-30.384 20.26-70.158 18.753-98.954-3.75-28.797-22.504-40.24-61.021-28.47-95.829C36.346 23.392 68.723.002 105.127.006L105.11 0z"/>
+            <path fill="url(#c)"
+                  d="M118.98 13c36.39-.004 66.531 28.98 68.875 66.234 2.343 37.253-23.915 69.971-60.006 74.766 29.604-8.654 48.403-38.434 43.99-69.685-4.413-31.25-30.678-54.333-61.459-54.014-30.78.32-56.584 23.944-60.38 55.28v-1.777C49.99 44.714 80.872 13.016 118.98 13z"/>
+        </g>
+    </svg>
+    <div
+        class="flex flex-col items-center w-full max-w-lg p-10 mx-auto mt-8 bg-white border border-gray-100 shadow-xl rounded-xl">
+        <h1 class="text-3xl font-semibold text-green-400">Successfully Installed 🎉</h1>
+        <p class="mt-5 text-gray-500">Click the continue button below to view your new SAAS application.</p>
+        <a href="/"
+           class="flex justify-center w-full px-4 py-2 mt-8 text-lg font-medium text-white transition duration-150 ease-in-out bg-blue-600 border border-transparent rounded-md hover:bg-blue-500 focus:outline-none focus:border-blue-700 focus:shadow-outline-wave active:bg-blue-700">
+            Continue
+        </a>
+    </div>
+</div>
 
+<div class="flex flex-col items-center justify-center w-screen h-screen">
+    <svg class="w-20 h-20 -mt-12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 206">
+        <defs/>
+        <defs>
+            <linearGradient id="a" x1="100%" x2="0%" y1="45.596%" y2="45.596%">
+                <stop offset="0%" stop-color="#5D63FB"/>
+                <stop offset="100%" stop-color="#0769FF"/>
+            </linearGradient>
+            <linearGradient id="b" x1="50%" x2="50%" y1="0%" y2="100%">
+                <stop offset="0%" stop-color="#39BEFF"/>
+                <stop offset="100%" stop-color="#0769FF"/>
+            </linearGradient>
+            <linearGradient id="c" x1="0%" x2="99.521%" y1="50%" y2="50%">
+                <stop offset="0%" stop-color="#38BCFF"/>
+                <stop offset="99.931%" stop-color="#91D8FF"/>
+            </linearGradient>
+        </defs>
+        <g fill="none" fill-rule="evenodd">
+            <path fill="url(#a)"
+                  d="M185.302 38c14.734 18.317 22.742 41.087 22.698 64.545C208 159.68 161.43 206 103.986 206c-39.959-.01-76.38-22.79-93.702-58.605C-7.04 111.58-2.203 69.061 22.727 38a104.657 104.657 0 00-9.283 43.352c0 54.239 40.55 98.206 90.57 98.206 50.021 0 90.571-43.973 90.571-98.206A104.657 104.657 0 00185.302 38z"/>
+            <path fill="url(#b)"
+                  d="M105.11 0A84.144 84.144 0 01152 14.21C119.312-.651 80.806 8.94 58.7 37.45c-22.105 28.51-22.105 68.58 0 97.09 22.106 28.51 60.612 38.101 93.3 23.239-30.384 20.26-70.158 18.753-98.954-3.75-28.797-22.504-40.24-61.021-28.47-95.829C36.346 23.392 68.723.002 105.127.006L105.11 0z"/>
+            <path fill="url(#c)"
+                  d="M118.98 13c36.39-.004 66.531 28.98 68.875 66.234 2.343 37.253-23.915 69.971-60.006 74.766 29.604-8.654 48.403-38.434 43.99-69.685-4.413-31.25-30.678-54.333-61.459-54.014-30.78.32-56.584 23.944-60.38 55.28v-1.777C49.99 44.714 80.872 13.016 118.98 13z"/>
+        </g>
+    </svg>
+    <div
+        class="flex flex-col items-center w-full max-w-lg p-10 mx-auto mt-8 bg-white border border-gray-100 shadow-xl rounded-xl">
+        <h1 class="text-3xl font-semibold text-blue-600">Welcome to Wave</h1>
+        <p class="mt-5 text-gray-500">If you're ready to get started, click on the 'Install Wave' button below. In this
+            future this installation screen will have a few setup options.</p>
+        <a href="/install?complete=true"
+           class="flex justify-center w-full px-4 py-2 mt-8 text-lg font-medium text-white transition duration-150 ease-in-out bg-blue-600 border border-transparent rounded-md hover:bg-blue-500 focus:outline-none focus:border-blue-700 focus:shadow-outline-wave active:bg-blue-700">
+            Install Wave
+        </a>
+    </div>
+</div>
 
+</body>
+</html>
 
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Wave Installation</title>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.4/tailwind.min.css">
-    </head>
-    <body class="bg-gray-50">
-
-
-            @if(Request::get('complete'))
-
-                @php
-
-                    \Illuminate\Support\Facades\Artisan::call('db:seed', [
-                    '--force' => true
-                    ]);
-
-                    \Illuminate\Support\Facades\Artisan::call('storage:link');
-
-                 @endphp
-
-                 <div class="flex flex-col items-center justify-center w-screen h-screen">
-                    <svg class="w-20 h-20 -mt-12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 206"><defs/><defs><linearGradient id="a" x1="100%" x2="0%" y1="45.596%" y2="45.596%"><stop offset="0%" stop-color="#5D63FB"/><stop offset="100%" stop-color="#0769FF"/></linearGradient><linearGradient id="b" x1="50%" x2="50%" y1="0%" y2="100%"><stop offset="0%" stop-color="#39BEFF"/><stop offset="100%" stop-color="#0769FF"/></linearGradient><linearGradient id="c" x1="0%" x2="99.521%" y1="50%" y2="50%"><stop offset="0%" stop-color="#38BCFF"/><stop offset="99.931%" stop-color="#91D8FF"/></linearGradient></defs><g fill="none" fill-rule="evenodd"><path fill="url(#a)" d="M185.302 38c14.734 18.317 22.742 41.087 22.698 64.545C208 159.68 161.43 206 103.986 206c-39.959-.01-76.38-22.79-93.702-58.605C-7.04 111.58-2.203 69.061 22.727 38a104.657 104.657 0 00-9.283 43.352c0 54.239 40.55 98.206 90.57 98.206 50.021 0 90.571-43.973 90.571-98.206A104.657 104.657 0 00185.302 38z"/><path fill="url(#b)" d="M105.11 0A84.144 84.144 0 01152 14.21C119.312-.651 80.806 8.94 58.7 37.45c-22.105 28.51-22.105 68.58 0 97.09 22.106 28.51 60.612 38.101 93.3 23.239-30.384 20.26-70.158 18.753-98.954-3.75-28.797-22.504-40.24-61.021-28.47-95.829C36.346 23.392 68.723.002 105.127.006L105.11 0z"/><path fill="url(#c)" d="M118.98 13c36.39-.004 66.531 28.98 68.875 66.234 2.343 37.253-23.915 69.971-60.006 74.766 29.604-8.654 48.403-38.434 43.99-69.685-4.413-31.25-30.678-54.333-61.459-54.014-30.78.32-56.584 23.944-60.38 55.28v-1.777C49.99 44.714 80.872 13.016 118.98 13z"/></g></svg>
-                    <div class="flex flex-col items-center w-full max-w-lg p-10 mx-auto mt-8 bg-white border border-gray-100 shadow-xl rounded-xl">
-                        <h1 class="text-3xl font-semibold text-green-400">Successfully Installed 🎉</h1>
-                        <p class="mt-5 text-gray-500">Click the continue button below to view your new SAAS application.</p>
-                        <a href="/" class="flex justify-center w-full px-4 py-2 mt-8 text-lg font-medium text-white transition duration-150 ease-in-out bg-blue-600 border border-transparent rounded-md hover:bg-blue-500 focus:outline-none focus:border-blue-700 focus:shadow-outline-wave active:bg-blue-700">
-                            Continue
-                        </a>
-                    </div>
-                </div>
-
-            @else
-
-                <div class="flex flex-col items-center justify-center w-screen h-screen">
-                    <svg class="w-20 h-20 -mt-12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208 206"><defs/><defs><linearGradient id="a" x1="100%" x2="0%" y1="45.596%" y2="45.596%"><stop offset="0%" stop-color="#5D63FB"/><stop offset="100%" stop-color="#0769FF"/></linearGradient><linearGradient id="b" x1="50%" x2="50%" y1="0%" y2="100%"><stop offset="0%" stop-color="#39BEFF"/><stop offset="100%" stop-color="#0769FF"/></linearGradient><linearGradient id="c" x1="0%" x2="99.521%" y1="50%" y2="50%"><stop offset="0%" stop-color="#38BCFF"/><stop offset="99.931%" stop-color="#91D8FF"/></linearGradient></defs><g fill="none" fill-rule="evenodd"><path fill="url(#a)" d="M185.302 38c14.734 18.317 22.742 41.087 22.698 64.545C208 159.68 161.43 206 103.986 206c-39.959-.01-76.38-22.79-93.702-58.605C-7.04 111.58-2.203 69.061 22.727 38a104.657 104.657 0 00-9.283 43.352c0 54.239 40.55 98.206 90.57 98.206 50.021 0 90.571-43.973 90.571-98.206A104.657 104.657 0 00185.302 38z"/><path fill="url(#b)" d="M105.11 0A84.144 84.144 0 01152 14.21C119.312-.651 80.806 8.94 58.7 37.45c-22.105 28.51-22.105 68.58 0 97.09 22.106 28.51 60.612 38.101 93.3 23.239-30.384 20.26-70.158 18.753-98.954-3.75-28.797-22.504-40.24-61.021-28.47-95.829C36.346 23.392 68.723.002 105.127.006L105.11 0z"/><path fill="url(#c)" d="M118.98 13c36.39-.004 66.531 28.98 68.875 66.234 2.343 37.253-23.915 69.971-60.006 74.766 29.604-8.654 48.403-38.434 43.99-69.685-4.413-31.25-30.678-54.333-61.459-54.014-30.78.32-56.584 23.944-60.38 55.28v-1.777C49.99 44.714 80.872 13.016 118.98 13z"/></g></svg>
-                    <div class="flex flex-col items-center w-full max-w-lg p-10 mx-auto mt-8 bg-white border border-gray-100 shadow-xl rounded-xl">
-                        <h1 class="text-3xl font-semibold text-blue-600">Welcome to Wave</h1>
-                        <p class="mt-5 text-gray-500">If you're ready to get started, click on the 'Install Wave' button below. In this future this installation screen will have a few setup options.</p>
-                        <a href="/install?complete=true" class="flex justify-center w-full px-4 py-2 mt-8 text-lg font-medium text-white transition duration-150 ease-in-out bg-blue-600 border border-transparent rounded-md hover:bg-blue-500 focus:outline-none focus:border-blue-700 focus:shadow-outline-wave active:bg-blue-700">
-                            Install Wave
-                        </a>
-                    </div>
-                </div>
-
-            @endif
-
-
-
-
-    </body>
-    </html>
-
-
-@endif

--- a/wave/routes/api.php
+++ b/wave/routes/api.php
@@ -12,10 +12,12 @@ Route::controller(AuthController::class)->group(function () {
     Route::post('token', 'token');
 });
 
-Route::controller(ApiController::class)->group(function () {
-    Route::get('{datatype}', 'browse');
-    Route::get('{datatype}/{id}', 'read');
-    Route::put('{datatype}/{id}', 'edit');
-    Route::post('{datatype}', 'add');
-    Route::delete('{datatype}/{id}', 'delete');
-});
+Route::middleware(['auth:api'])
+    ->controller(ApiController::class)
+    ->group(function () {
+        Route::get('{datatype}', 'browse');
+        Route::get('{datatype}/{id}', 'read');
+        Route::put('{datatype}/{id}', 'edit');
+        Route::post('{datatype}', 'add');
+        Route::delete('{datatype}/{id}', 'delete');
+    });

--- a/wave/routes/api.php
+++ b/wave/routes/api.php
@@ -1,24 +1,21 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Wave\Http\Controllers\API\ApiController;
+use Wave\Http\Controllers\API\AuthController;
 
-Route::post('login', '\Wave\Http\Controllers\API\AuthController@login');
-Route::post('register', '\Wave\Http\Controllers\API\AuthController@register');
-Route::post('logout', '\Wave\Http\Controllers\API\AuthController@logout');
-Route::post('refresh', '\Wave\Http\Controllers\API\AuthController@refresh');
-Route::post('token', '\Wave\Http\Controllers\API\AuthController@token');
+Route::controller(AuthController::class)->group(function () {
+    Route::post('login', 'login');
+    Route::post('register', 'register');
+    Route::post('logout', 'logout');
+    Route::post('refresh', 'refresh');
+    Route::post('token', 'token');
+});
 
-// BROWSE
-Route::get('/{datatype}', '\Wave\Http\Controllers\API\ApiController@browse');
-
-// READ
-Route::get('/{datatype}/{id}', '\Wave\Http\Controllers\API\ApiController@read');
-
-// EDIT
-Route::put('/{datatype}/{id}', '\Wave\Http\Controllers\API\ApiController@edit');
-
-// ADD
-Route::post('/{datatype}', '\Wave\Http\Controllers\API\ApiController@add');
-
-// DELETE
-Route::delete('/{datatype}/{id}', '\Wave\Http\Controllers\API\ApiController@delete');
+Route::controller(ApiController::class)->group(function () {
+    Route::get('{datatype}', 'browse');
+    Route::get('{datatype}/{id}', 'read');
+    Route::put('{datatype}/{id}', 'edit');
+    Route::post('{datatype}', 'add');
+    Route::delete('{datatype}/{id}', 'delete');
+});

--- a/wave/routes/web.php
+++ b/wave/routes/web.php
@@ -1,71 +1,109 @@
 <?php
 
+use App\Http\Controllers\Auth\RegisterController;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
+use Wave\Http\Controllers\AnnouncementController;
+use Wave\Http\Controllers\Auth\LoginController;
+use Wave\Http\Controllers\BlogController;
+use Wave\Http\Controllers\DashboardController;
+use Wave\Http\Controllers\HomeController;
+use Wave\Http\Controllers\NotificationController;
+use Wave\Http\Controllers\PageController;
+use Wave\Http\Controllers\ProfileController;
+use Wave\Http\Controllers\SettingsController;
+use Wave\Http\Controllers\SubscriptionController;
 
 Route::impersonate();
-
-Route::get('/', '\Wave\Http\Controllers\HomeController@index')->name('wave.home');
-Route::get('@{username}', '\Wave\Http\Controllers\ProfileController@index')->name('wave.profile');
 
 // Documentation routes
 Route::view('docs/{page?}', 'docs::index')->where('page', '(.*)');
 
-// Additional Auth Routes
-Route::get('logout', '\Wave\Http\Controllers\Auth\LoginController@logout')->name('wave.logout');
-Route::get('user/verify/{verification_code}', '\Wave\Http\Controllers\Auth\RegisterController@verify')->name('verify');
-Route::post('register/complete', '\Wave\Http\Controllers\Auth\RegisterController@complete')->name('wave.register-complete');
-
-Route::get('blog', '\Wave\Http\Controllers\BlogController@index')->name('wave.blog');
-Route::get('blog/{category}', '\Wave\Http\Controllers\BlogController@category')->name('wave.blog.category');
-Route::get('blog/{category}/{post}', '\Wave\Http\Controllers\BlogController@post')->name('wave.blog.post');
-
-Route::view('install', 'wave::install')->name('wave.install');
-
-/***** Pages *****/
-Route::get('p/{page}', '\Wave\Http\Controllers\PageController@page');
-
-/***** Pricing Page *****/
 Route::view('pricing', 'theme::pricing')->name('wave.pricing');
 
-/***** Billing Routes *****/
+// Billing Routes
 Route::post('paddle/webhook', '\Wave\Http\Controllers\WebhookController');
-Route::post('checkout', '\Wave\Http\Controllers\SubscriptionController@checkout')->name('checkout');
 
-Route::get('test', '\Wave\Http\Controllers\SubscriptionController@test');
+Route::get('p/{page}', [PageController::class, 'page']);
+
+// Additional Auth Routes
+Route::get('logout', [LoginController::class, 'logout'])->name('wave.logout');
+
+Route::get('/', [HomeController::class, 'index'])->name('wave.home');
+
+Route::get('@{username}', [ProfileController::class, 'index'])->name('wave.profile');
+
+Route::get('install', function () {
+    if (!User::first()->exists()) {
+        Artisan::command('db:seed', ['--force' => true]);
+        Artisan::call('storage:link');
+    }
+
+    return view('wave::install');
+})->name('wave.install');
+
+Route::controller(RegisterController::class)->group(function () {
+    Route::get('user/verify/{verification_code}', 'verify')->name('wave.register');
+    Route::post('register/complete', 'complete')->name('wave.register-complete');;
+});
+
+Route::controller(BlogController::class)->prefix('blog')->group(function () {
+    Route::get('', 'index')->name('wave.blog');
+    Route::get('{category}', 'category')->name('wave.blog.category');
+    Route::get('{category}/{post}', 'post')->name('wave.blog.post');
+});
+
+Route::controller(SubscriptionController::class)->group(function () {
+    Route::get('test', 'test');
+    Route::post('checkout', 'checkout')->name('checkout');
+});
 
 Route::group(['middleware' => 'wave'], function () {
-	Route::get('dashboard', '\Wave\Http\Controllers\DashboardController@index')->name('wave.dashboard');
+    Route::get('dashboard', [DashboardController::class, 'index'])->name('wave.dashboard');
 });
 
-Route::group(['middleware' => 'auth'], function(){
-	Route::get('settings/{section?}', '\Wave\Http\Controllers\SettingsController@index')->name('wave.settings');
-
-	Route::post('settings/profile', '\Wave\Http\Controllers\SettingsController@profilePut')->name('wave.settings.profile.put');
-	Route::put('settings/security', '\Wave\Http\Controllers\SettingsController@securityPut')->name('wave.settings.security.put');
-
-	Route::post('settings/api', '\Wave\Http\Controllers\SettingsController@apiPost')->name('wave.settings.api.post');
-	Route::put('settings/api/{id?}', '\Wave\Http\Controllers\SettingsController@apiPut')->name('wave.settings.api.put');
-	Route::delete('settings/api/{id?}', '\Wave\Http\Controllers\SettingsController@apiDelete')->name('wave.settings.api.delete');
-
-	Route::get('settings/invoices/{invoice}', '\Wave\Http\Controllers\SettingsController@invoice')->name('wave.invoice');
-
-	Route::get('notifications', '\Wave\Http\Controllers\NotificationController@index')->name('wave.notifications');
-	Route::get('announcements', '\Wave\Http\Controllers\AnnouncementController@index')->name('wave.announcements');
-	Route::get('announcement/{id}', '\Wave\Http\Controllers\AnnouncementController@announcement')->name('wave.announcement');
-	Route::post('announcements/read', '\Wave\Http\Controllers\AnnouncementController@read')->name('wave.announcements.read');
-	Route::get('notifications', '\Wave\Http\Controllers\NotificationController@index')->name('wave.notifications');
-	Route::post('notification/read/{id}', '\Wave\Http\Controllers\NotificationController@delete')->name('wave.notification.read');
-
-    /********** Checkout/Billing Routes ***********/
-    Route::post('cancel', '\Wave\Http\Controllers\SubscriptionController@cancel')->name('wave.cancel');
-    Route::view('checkout/welcome', 'theme::welcome');
-
-    Route::post('subscribe', '\Wave\Http\Controllers\SubscriptionController@subscribe')->name('wave.subscribe');
-	Route::view('trial_over', 'theme::trial_over')->name('wave.trial_over');
-	Route::view('cancelled', 'theme::cancelled')->name('wave.cancelled');
-    Route::post('switch-plans', '\Wave\Http\Controllers\SubscriptionController@switchPlans')->name('wave.switch-plans');
-});
-
-Route::group(['middleware' => 'admin.user'], function(){
+Route::group(['middleware' => 'admin.user'], function () {
     Route::view('admin/do', 'wave::do');
+});
+
+Route::group(['middleware' => 'auth'], function () {
+
+    Route::view('checkout/welcome', 'theme::welcome');
+    Route::view('trial_over', 'theme::trial_over')->name('wave.trial_over');
+    Route::view('cancelled', 'theme::cancelled')->name('wave.cancelled');
+
+    Route::controller(SettingsController::class)
+        ->prefix('settings')
+        ->group(function () {
+            Route::get('{section?}', 'index')->name('wave.settings');
+            Route::post('profile', 'profilePut')->name('wave.settings.profile.put');
+            Route::put('security', 'securityPut')->name('wave.settings.security.put');
+            Route::post('api', 'apiPost')->name('wave.settings.api.post');
+            Route::put('api/{id?}', 'apiPut')->name('wave.settings.api.put');
+            Route::delete('api/{id?}', 'apiDelete')->name('wave.settings.api.delete');
+            Route::get('invoices/{invoice}', 'invoice')->name('wave.invoice');
+        });
+
+    Route::controller(AnnouncementController::class)
+        ->prefix('announcements')
+        ->group(function () {
+            Route::get('', 'index')->name('wave.announcements');
+            Route::get('{id}', 'announcement')->name('wave.announcement');
+            Route::post('read', 'read')->name('wave.announcements.read');
+        });
+
+    Route::controller(NotificationController::class)
+        ->prefix('notifications')
+        ->group(function () {
+            Route::get('', 'index')->name('wave.notifications');
+            Route::post('read/{id}', 'delete')->name('wave.notification.read');
+        });
+
+    Route::controller(SubscriptionController::class)
+        ->group(function () {
+            Route::post('subscribe', 'subscribe')->name('wave.subscribe');
+            Route::post('switch-plans', 'switchPlans')->name('wave.switch-plans');
+            Route::post('cancel', 'cancel')->name('wave.cancel');
+        });
 });

--- a/wave/routes/web.php
+++ b/wave/routes/web.php
@@ -43,17 +43,6 @@ Route::get('install', function () {
     return view('wave::install');
 })->name('wave.install');
 
-Route::controller(RegisterController::class)->group(function () {
-    Route::get('user/verify/{verification_code}', 'verify')->name('wave.register');
-    Route::post('register/complete', 'complete')->name('wave.register-complete');;
-});
-
-Route::controller(BlogController::class)->prefix('blog')->group(function () {
-    Route::get('', 'index')->name('wave.blog');
-    Route::get('{category}', 'category')->name('wave.blog.category');
-    Route::get('{category}/{post}', 'post')->name('wave.blog.post');
-});
-
 Route::controller(SubscriptionController::class)->group(function () {
     Route::get('test', 'test');
     Route::post('checkout', 'checkout')->name('checkout');
@@ -67,43 +56,59 @@ Route::group(['middleware' => 'admin.user'], function () {
     Route::view('admin/do', 'wave::do');
 });
 
-Route::group(['middleware' => 'auth'], function () {
+Route::controller(RegisterController::class)
+    ->name('wave.')
+    ->group(function () {
+        Route::get('user/verify/{verification_code}', 'verify')->name('register');
+        Route::post('register/complete', 'complete')->name('register-complete');;
+    });
 
-    Route::view('checkout/welcome', 'theme::welcome');
-    Route::view('trial_over', 'theme::trial_over')->name('wave.trial_over');
-    Route::view('cancelled', 'theme::cancelled')->name('wave.cancelled');
+Route::controller(BlogController::class)
+    ->name('wave.')
+    ->prefix('blog')->group(function () {
+        Route::get('', 'index')->name('blog');
+        Route::get('{category}', 'category')->name('blog.category');
+        Route::get('{category}/{post}', 'post')->name('blog.post');
+    });
 
-    Route::controller(SettingsController::class)
-        ->prefix('settings')
-        ->group(function () {
-            Route::get('{section?}', 'index')->name('wave.settings');
-            Route::post('profile', 'profilePut')->name('wave.settings.profile.put');
-            Route::put('security', 'securityPut')->name('wave.settings.security.put');
-            Route::post('api', 'apiPost')->name('wave.settings.api.post');
-            Route::put('api/{id?}', 'apiPut')->name('wave.settings.api.put');
-            Route::delete('api/{id?}', 'apiDelete')->name('wave.settings.api.delete');
-            Route::get('invoices/{invoice}', 'invoice')->name('wave.invoice');
-        });
+Route::name('wave.')
+    ->middleware(['auth'])
+    ->group(function () {
+        Route::view('checkout/welcome', 'theme::welcome');
+        Route::view('trial_over', 'theme::trial_over')->name('trial_over');
+        Route::view('cancelled', 'theme::cancelled')->name('cancelled');
 
-    Route::controller(AnnouncementController::class)
-        ->prefix('announcements')
-        ->group(function () {
-            Route::get('', 'index')->name('wave.announcements');
-            Route::get('{id}', 'announcement')->name('wave.announcement');
-            Route::post('read', 'read')->name('wave.announcements.read');
-        });
+        Route::controller(SettingsController::class)
+            ->prefix('settings')
+            ->group(function () {
+                Route::get('{section?}', 'index')->name('settings');
+                Route::post('profile', 'profilePut')->name('settings.profile.put');
+                Route::put('security', 'securityPut')->name('settings.security.put');
+                Route::post('api', 'apiPost')->name('settings.api.post');
+                Route::put('api/{id?}', 'apiPut')->name('settings.api.put');
+                Route::delete('api/{id?}', 'apiDelete')->name('settings.api.delete');
+                Route::get('invoices/{invoice}', 'invoice')->name('invoice');
+            });
 
-    Route::controller(NotificationController::class)
-        ->prefix('notifications')
-        ->group(function () {
-            Route::get('', 'index')->name('wave.notifications');
-            Route::post('read/{id}', 'delete')->name('wave.notification.read');
-        });
+        Route::controller(AnnouncementController::class)
+            ->prefix('announcements')
+            ->group(function () {
+                Route::get('', 'index')->name('announcements');
+                Route::get('{id}', 'announcement')->name('announcement');
+                Route::post('read', 'read')->name('announcements.read');
+            });
 
-    Route::controller(SubscriptionController::class)
-        ->group(function () {
-            Route::post('subscribe', 'subscribe')->name('wave.subscribe');
-            Route::post('switch-plans', 'switchPlans')->name('wave.switch-plans');
-            Route::post('cancel', 'cancel')->name('wave.cancel');
-        });
-});
+        Route::controller(NotificationController::class)
+            ->prefix('notifications')
+            ->group(function () {
+                Route::get('', 'index')->name('notifications');
+                Route::post('read/{id}', 'delete')->name('notification.read');
+            });
+
+        Route::controller(SubscriptionController::class)
+            ->group(function () {
+                Route::post('subscribe', 'subscribe')->name('subscribe');
+                Route::post('switch-plans', 'switchPlans')->name('switch-plans');
+                Route::post('cancel', 'cancel')->name('cancel');
+            });
+    });

--- a/wave/src/Http/Controllers/API/ApiController.php
+++ b/wave/src/Http/Controllers/API/ApiController.php
@@ -13,11 +13,6 @@ use TCG\Voyager\Models\DataType;
 class ApiController extends Controller
 {
 
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
 	use BreadRelationshipParser;
     //*********************************************
     //               ____


### PR DESCRIPTION
- Group routes by `controller` method
- Group routes using `prefix`
- Organize routes by HTTP verb
- Remove artisan commands that were being called from the template file (now being called on the routes file)