### PR TITLE
Improve queries to read announcements

### DIFF
--- a/wave/src/Http/Controllers/AnnouncementController.php
+++ b/wave/src/Http/Controllers/AnnouncementController.php
@@ -3,27 +3,32 @@
 namespace Wave\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Database\Query\Builder;
 use Wave\Announcement;
 
 class AnnouncementController extends Controller
 {
-    public function index(){
-    	$announcements = Announcement::paginate(10);
+    public function index()
+    {
+        $announcements = Announcement::paginate(10);
         return view('theme::announcements.index', compact('announcements'));
     }
 
-    public function announcement($id){
+    public function announcement($id)
+    {
         $announcement = Announcement::find($id);
-    	return view('theme::announcements.announcement', compact('announcement'));
+        return view('theme::announcements.announcement', compact('announcement'));
     }
 
-    public function read(){
-    	$user = auth()->user();
-    	$announcements = Announcement::all();
-    	foreach($announcements as $announcement){
-            if(!$user->announcements()->where('id', $announcement->id)->exists()){
-    		  $user->announcements()->attach($announcement->id);
-            }
-    	}
+    public function read()
+    {
+        $user = auth()->user();
+        Announcement::whereDoesntHave('users', function ($query) use ($user) {
+            $query->where('user_id', $user->id);
+        })->get()
+            ->pluck('id')
+            ->tap(function ($missingAnnouncements) use ($user) {
+                $user->announcements()->attach($missingAnnouncements->toArray());
+            });
     }
 }


### PR DESCRIPTION
This change improve the number of queries regarding the reading of announcements.

### Before

1. Retrieve `all` announcements (may be slow when the table is big)
2. Check if the user doesn't already have the announcement (call `N` times the announcement table)
3. Attach each missing announcement to the user (call `N` times the announcement table)

### Now

1. Retrieve all announcements that the user doesn't have (1 query)
2. Attach all announcements to the user (1 query)