### PR TITLE
fix: removed dd() in UserRegistered Listener

### DIFF
--- a/app/Listeners/UserRegistered.php
+++ b/app/Listeners/UserRegistered.php
@@ -21,7 +21,6 @@ class UserRegistered
      */
     public function handle(Registered $event): void
     {
-        dd($event)
         // $user = $event->user;
         // Perform any functionality to the user here...
     }


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x]  Bugfix
- [ ]  Feature
- [ ]  Code style update
- [x]  Refactor
- [ ]  Build-related changes

### Description:
There was **dd($event)** in handle method of **UserRegistered** Listener which wasn't supposed to be in the production build.

### Fixes Implemented:
This PR removes the **dd($event)** probably used during development and testing period in **UserRegistered** Event Listener.

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

### Related Issue
None