### PR TITLE
fix: added validation unique for slug

### DIFF
--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -30,7 +30,7 @@ class CategoryResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
-                    ->unique()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\Select::make('parent_id')
                     ->label('Parent Category')

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -30,6 +30,7 @@ class CategoryResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
+                    ->unique()
                     ->maxLength(191),
                 Forms\Components\Select::make('parent_id')
                     ->label('Parent Category')

--- a/app/Filament/Resources/FormsResource.php
+++ b/app/Filament/Resources/FormsResource.php
@@ -49,7 +49,7 @@ class FormsResource extends Resource
                 TextInput::make('slug')
                     ->label('Slug')
                     ->required()
-                    ->unique()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
 
                 Repeater::make('fields')

--- a/app/Filament/Resources/FormsResource.php
+++ b/app/Filament/Resources/FormsResource.php
@@ -40,15 +40,16 @@ class FormsResource extends Resource
         return $form
             ->schema([
                 TextInput::make('name')
-                ->label('Name')
-                ->required()
-                ->live(debounce: 500)
-                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state)))
-                ->maxLength(191),
+                    ->label('Name')
+                    ->required()
+                    ->live(debounce: 500)
+                    ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state)))
+                    ->maxLength(191),
 
                 TextInput::make('slug')
                     ->label('Slug')
                     ->required()
+                    ->unique()
                     ->maxLength(191),
 
                 Repeater::make('fields')

--- a/app/Filament/Resources/PageResource.php
+++ b/app/Filament/Resources/PageResource.php
@@ -35,7 +35,7 @@ class PageResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
-                    ->unique()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\RichEditor::make('body')
                     ->required()

--- a/app/Filament/Resources/PageResource.php
+++ b/app/Filament/Resources/PageResource.php
@@ -35,6 +35,7 @@ class PageResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
+                    ->unique()
                     ->maxLength(191),
                 Forms\Components\RichEditor::make('body')
                     ->required()

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -36,7 +36,7 @@ class PostResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
-                    ->unique()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\RichEditor::make('body')
                     ->required()

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -36,6 +36,7 @@ class PostResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
+                    ->unique()
                     ->maxLength(191),
                 Forms\Components\RichEditor::make('body')
                     ->required()


### PR DESCRIPTION
This pull request adds a unique validation check for the slug field to resolve the error it was causing.

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/1e335e57-638a-4495-9f88-efb42066958a">
