### PR TITLE
fix: adds validation unique for slug and key

### DIFF
--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -30,6 +30,7 @@ class CategoryResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\Select::make('parent_id')
                     ->label('Parent Category')

--- a/app/Filament/Resources/FormsResource.php
+++ b/app/Filament/Resources/FormsResource.php
@@ -40,15 +40,16 @@ class FormsResource extends Resource
         return $form
             ->schema([
                 TextInput::make('name')
-                ->label('Name')
-                ->required()
-                ->live(debounce: 500)
-                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state)))
-                ->maxLength(191),
+                    ->label('Name')
+                    ->required()
+                    ->live(debounce: 500)
+                    ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state)))
+                    ->maxLength(191),
 
                 TextInput::make('slug')
                     ->label('Slug')
                     ->required()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
 
                 Repeater::make('fields')

--- a/app/Filament/Resources/PageResource.php
+++ b/app/Filament/Resources/PageResource.php
@@ -35,6 +35,7 @@ class PageResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\RichEditor::make('body')
                     ->required()

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -36,6 +36,7 @@ class PostResource extends Resource
                     ->maxLength(191),
                 Forms\Components\TextInput::make('slug')
                     ->required()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\RichEditor::make('body')
                     ->required()

--- a/app/Filament/Resources/SettingResource.php
+++ b/app/Filament/Resources/SettingResource.php
@@ -27,6 +27,7 @@ class SettingResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('key')
                     ->required()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(191),
                 Forms\Components\TextInput::make('display_name')
                     ->required()


### PR DESCRIPTION
This pull request adds a unique validation check for the slug and key field to resolve the error it was causing.

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/814a145c-f024-45ba-9f9f-d79bc9185e63">
