### PR TITLE
Fix Dark Mode Compatibility for User and Post Widgets

### DIFF
--- a/wave/resources/views/widgets/posts-pages-widget.blade.php
+++ b/wave/resources/views/widgets/posts-pages-widget.blade.php
@@ -7,7 +7,7 @@
             
             <div class="w-full">
                 <div class="flex flex-col">
-                    <div class="mt-1 text-2xl font-semibold tracking-tight text-gray-900">{{ \Wave\Post::count() }}</div>
+                    <div class="mt-1 text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-200">{{ \Wave\Post::count() }}</div>
                 </div>
             </div>
             
@@ -22,7 +22,7 @@
             
             <div class="w-full">
                 <div class="flex flex-col">
-                    <div class="mt-1 text-xl font-semibold tracking-tight text-gray-900">{{ \Wave\Page::count() }}</div>
+                    <div class="mt-1 text-xl font-semibold tracking-tight text-gray-900 dark:text-gray-200">{{ \Wave\Page::count() }}</div>
                 </div>
             </div>
             

--- a/wave/resources/views/widgets/users-widget.blade.php
+++ b/wave/resources/views/widgets/users-widget.blade.php
@@ -7,7 +7,7 @@
             
             <div class="w-full">
                 <div class="flex flex-col">
-                    <div class="mt-1 text-2xl font-semibold tracking-tight text-gray-900">{{ \Wave\User::count() }}</div>
+                    <div class="mt-1 text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-200">{{ \Wave\User::count() }}</div>
                 </div>
             </div>
             
@@ -22,7 +22,7 @@
             
             <div class="w-full">
                 <div class="flex flex-col">
-                    <div class="mt-1 text-xl font-semibold tracking-tight text-gray-900">{{ \Wave\User::count() }}</div>
+                    <div class="mt-1 text-xl font-semibold tracking-tight text-gray-900 dark:text-gray-200">{{ \Wave\User::count() }}</div>
                 </div>
             </div>
             


### PR DESCRIPTION
This fixes dark mode support for text elements in the user and post widgets on the admin dashboard. Previously, some text within these widgets was not visible in dark mode due to lack of dark-specific styling. I added dark:text-gray-200 classes to relevant `<div>` elements to ensure readability in dark mode.

### Files Updated

    wave/resources/views/widgets/users-widget.blade.php
        Updated `<div>` elements for user count display:
            elements now include dark:text-gray-200 to ensure text visibility in dark mode.

    wave/resources/views/widgets/posts-pages-widget.blade.php
        Updated `<div>` elements for post and page count display:
            elements now include dark:text-gray-200 to ensure text visibility in dark mode.

### Styling Approach

I couldn't find a specific styling guide indicating what color should be used for dark mode text, I opted for text-gray-200, aligning with similar elements in the dashboard. 

### Testing

All changes were visually tested in both light and dark modes to confirm that text is now visible and consistent with other elements in the dashboard.