### PR TITLE
Make user avatar required

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -39,6 +39,7 @@ class UserResource extends Resource
                     ->required()
                     ->maxLength(191),
                 Forms\Components\FileUpload::make('avatar')
+                    ->required()
                     ->image(),
                 Forms\Components\DateTimePicker::make('email_verified_at'),
                 Forms\Components\TextInput::make('password')


### PR DESCRIPTION
As reported [here](https://devdojo.com/question/integrity-constraint-violation-19-not-null-constraint-failed-usersavatar), this fixes:

> Went to Admin > Users, Went to create a new User, then got an error when submitting the form; SQLSTATE[23000]: Integrity constraint violation: 19 NOT NULL constraint failed: users.avatar

