### PR TITLE
Error due to missing settings in /config/devdojo/auth

### DIFF
--- a/config/devdojo/auth/settings.php
+++ b/config/devdojo/auth/settings.php
@@ -7,10 +7,13 @@ return [
     'redirect_after_auth' => '/dashboard',
     'registration_show_password_same_screen' => true,
     'registration_include_name_field' => true,
+    'registration_include_password_confirmation_field' => false,
     'registration_require_email_verification' => false,
     'enable_branding' => true,
     'dev_mode' => false,
     'enable_2fa' => false, // Enable or disable 2FA functionality globally
     'login_show_social_providers' => true,
+    'center_align_social_provider_button_content' => false,
     'social_providers_location' => 'bottom',
+    'check_account_exists_before_login' => false,
 ];


### PR DESCRIPTION
As reported here: '[Wave 3 - Error due to missing settings in `/config/devdojo/auth`](https://devdojo.com/question/wave-3-error-due-to-missing-settings-in-configdevdojoauth)', adding the missing auth package config values.