### PR TITLE
Restrict for DevDojo Auth Setup to Admin users

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -55,6 +55,7 @@ class Kernel extends HttpKernel
      * @var array<string, class-string|string>
      */
     protected $routeMiddleware = [
+        'admin' => \App\Http\Middleware\AdminOnlyRoutes::class,
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,

--- a/app/Http/Middleware/AdminOnlyRoutes.php
+++ b/app/Http/Middleware/AdminOnlyRoutes.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class AdminOnlyRoutes
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->user() && $request->user()->hasRole('admin')) {
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,3 +16,10 @@ use Wave\Facades\Wave;
 
 // Wave routes
 Wave::routes();
+
+// Restriction for DevDojo Auth Setup - Restrict /auth/setup/* to admin users only
+Route::group(['prefix' => 'auth/setup', 'middleware' => ['auth', 'admin']], function () {
+    Route::any('{any}', function () {
+        return view('wave::auth.setup'); // Replace with the appropriate view or logic
+    })->where('any', '.*'); // Wildcard to match anything after /auth/setup/
+});


### PR DESCRIPTION
At the moment any user can visit the route `/auth/setup` and make changes. Restricting the /auth/setup/* to admin users only.
I also added AdminOnlyRoutes Middleware for future use, if there are other routes.