### PR TITLE
Fix page curd in admin

### DIFF
--- a/app/Filament/Resources/PageResource.php
+++ b/app/Filament/Resources/PageResource.php
@@ -46,7 +46,15 @@ class PageResource extends Resource
                     ->image(),
                 Forms\Components\Select::make('author_id')
                     ->label('Author')
-                    ->options(User::all()->pluck('name', 'id'))
+                    ->options(
+                        User::all()
+                            ->mapWithKeys(fn($user) => [
+                                $user->id => $user->name
+                                    ?? $user->username
+                                    ?? $user->email,
+                            ])
+                            ->toArray()
+                    )
                     ->searchable()
                     ->required(),
                 Forms\Components\Textarea::make('meta_description')


### PR DESCRIPTION
Fixes the following on the Page CRUD:

```
Filament\Forms\Components\Select::isOptionDisabled(): Argument #2 ($label) must be of type string, null given, called in /Users/biliev/Herd/wave3/vendor/filament/forms/src/Components/Select.php on line 191
```