### PR TITLE
Change social provider table to allow for larger token size

### DIFF
--- a/database/migrations/2025_02_19_101241_change_user_social_provider_table.php
+++ b/database/migrations/2025_02_19_101241_change_user_social_provider_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            $table->string('token',2048)->change();
+            $table->string('refresh_token',2048)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('social_provider_user', function (Blueprint $table) {
+            $table->string('token',191)->change();
+            $table->string('refresh_token',191)->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Token size was limited to string - varchar(191) for mysql- which is not suggested and also causing error with google Oauth2 which already requires larger tokens. 

(SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'token' at row 1)