### PR TITLE
Adding fix so that way volt components get added to the default livew…

### DIFF
--- a/app/Providers/VoltServiceProvider.php
+++ b/app/Providers/VoltServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Livewire\Volt\Volt;
+
+class VoltServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        Volt::mount([
+            config('livewire.view_path', resource_path('views/livewire')),
+            resource_path('views/pages'),
+        ]);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -202,6 +202,7 @@ return [
         App\Providers\FolioServiceProvider::class,
 
         \DevDojo\Themes\ThemesServiceProvider::class,
+        App\Providers\VoltServiceProvider::class,
 
     ],
 


### PR DESCRIPTION
This will fix it so that way when users type `php artisan make:volt counter`, it will add that component to the default `resources/views/livewire/` directory.