### PR TITLE
feat: allow refresh of expired tokens

### DIFF
--- a/wave/src/Http/Controllers/API/AuthController.php
+++ b/wave/src/Http/Controllers/API/AuthController.php
@@ -19,7 +19,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth:api', ['except' => ['login', 'token', 'register']]);
+        $this->middleware('auth:api', ['except' => ['login', 'token', 'register', 'refresh']]);
     }
 
     /**
@@ -79,7 +79,7 @@ class AuthController extends Controller
      */
     public function refresh()
     {
-        return $this->respondWithToken(auth()->refresh());
+        return $this->respondWithToken(auth('api')->refresh());
     }
 
     /**

--- a/wave/src/Http/Controllers/API/AuthController.php
+++ b/wave/src/Http/Controllers/API/AuthController.php
@@ -20,6 +20,7 @@ class AuthController extends Controller
     public function __construct()
     {
         $this->middleware('auth:api', ['except' => ['login', 'token', 'register', 'refresh']]);
+        $this->middleware('jwt.refresh')->only('refresh');
     }
 
     /**


### PR DESCRIPTION
The `/api/refresh` endpoint currently doesn't allow refreshing an expired token. It doesn't seem to respect the `refresh_ttl` setting from `config/jwt.php`, which defines how long a token can be refreshed after expiration.

Expected Behavior:
- The `/api/refresh` endpoint should allow refreshing expired tokens within the time window defined by `refresh_ttl`.