### PR TITLE
Ensure plugin autoloader registers once

### DIFF
--- a/tests/Unit/PluginAutoloaderTest.php
+++ b/tests/Unit/PluginAutoloaderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Wave\Plugins\PluginAutoloader;
+
+it('registers the plugin autoloader only once', function () {
+    $before = spl_autoload_functions() ?: [];
+
+    PluginAutoloader::register();
+    PluginAutoloader::register();
+
+    $after = spl_autoload_functions() ?: [];
+
+    // Count closures originating from PluginAutoloader
+    $pluginClosures = array_filter($after, function ($loader) {
+        if ($loader instanceof Closure) {
+            $ref = new ReflectionFunction($loader);
+            return str_contains($ref->getFileName(), 'PluginAutoloader.php');
+        }
+        return false;
+    });
+
+    expect(count($pluginClosures))->toBe(1)
+        ->and(count($after))->toBe(count($before) + 1);
+});

--- a/wave/src/Plugins/PluginAutoloader.php
+++ b/wave/src/Plugins/PluginAutoloader.php
@@ -7,8 +7,19 @@ use Illuminate\Support\Facades\File;
 
 class PluginAutoloader
 {
+    /**
+     * Indicates if the autoloader has been registered.
+     *
+     * @var bool
+     */
+    protected static $registered = false;
+
     public static function register()
     {
+        if (self::$registered) {
+            return;
+        }
+
         spl_autoload_register(function ($class) {
             $prefix = 'Wave\\Plugins\\';
             $base_dir = resource_path('plugins/');
@@ -41,5 +52,7 @@ class PluginAutoloader
                 return;
             }
         });
+
+        self::$registered = true;
     }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate PluginAutoloader registrations
- add a unit test verifying idempotent registration

## Testing
- `vendor/bin/pest` *(fails: No application encryption key specified / could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68572c1ebb008321b1da56647c75c957