### PR TITLE
Use filament setting to define storage disk for Post

### DIFF
--- a/wave/src/Post.php
+++ b/wave/src/Post.php
@@ -22,7 +22,7 @@ class Post extends Model
 
     public function image()
     {
-        return Storage::url($this->image);
+        return Storage::disk(config('filament.default_filesystem_disk'))->url($this->image);
     }
 
     public function category(): BelongsTo


### PR DESCRIPTION
Post use the default Storage disk so when I try to use a S3 bucket instead, it does not work.

I do not want to change the default storage disk of my Laravel application. I just want that post images are stored on S3.
So I try to change the filament setting like this:
```
<?php

return [

    /*
    |--------------------------------------------------------------------------
    | Default Filesystem Disk
    |--------------------------------------------------------------------------
    |
    | This is the storage disk Filament will use to store files. You may use
    | any of the disks defined in the `config/filesystems.php`.
    |
    */

    'default_filesystem_disk' => env('FILAMENT_FILESYSTEM_DISK', 'wave-media'),

];
```
Where `wave-media` is the name of my S3 storage.

When I change the line of code from my PR, it works.

Let me know if this is a needed change or if I miss something.