### PR TITLE
Fix default text color, only apply on layer base

### DIFF
--- a/resources/themes/anchor/assets/css/app.css
+++ b/resources/themes/anchor/assets/css/app.css
@@ -82,11 +82,11 @@
 }
 
 @layer base {
-html, body{
-  p{
-    @apply text-gray-500 dark:text-gray-400;
+  html, body{
+    p{
+      @apply text-gray-500 dark:text-gray-400;
+    }
   }
-}
 }
 
 .scrollbar-hidden::-webkit-scrollbar {


### PR DESCRIPTION
Fix default text color, only apply on layer base. with @layer base, override  of the text-color is  possible, without it is not .  behavior changed in tailwind v4