### PR TITLE
Use Filament default filesystem disk setting instead of 'public' for posts

### DIFF
--- a/app/Filament/Resources/Posts/PostResource.php
+++ b/app/Filament/Resources/Posts/PostResource.php
@@ -51,7 +51,7 @@ class PostResource extends Resource
                     ->maxLength(191),
                 RichEditor::make('body')
                     ->required()
-                    ->fileAttachmentsDisk('public')
+                    ->fileAttachmentsDisk(config('filament.default_filesystem_disk'))
                     ->fileAttachmentsDirectory('attachments')
                     ->fileAttachmentsVisibility('public')
                     ->columnSpanFull(),
@@ -59,7 +59,7 @@ class PostResource extends Resource
                     ->columnSpanFull(),
                 FileUpload::make('image')
                     ->image()
-                    ->disk('public')
+                    ->disk(config('filament.default_filesystem_disk'))
                     ->directory('posts'),
                 TextInput::make('seo_title')
                     ->maxLength(191),


### PR DESCRIPTION
PostResource use the 'public' storage disk so when I try to use a S3 bucket instead, it does not work.

My PR use Filament default filesystem disk setting instead of 'public' hardcoded one to allow configuration changes.

