### PR TITLE
feat: add Persian (fa) locale translations

### DIFF
--- a/lang/fa/auth.php
+++ b/lang/fa/auth.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'اطلاعات وارد شده با مشخصات ما مطابقت ندارد.',
+    'password' => 'رمز عبور وارد شده اشتباه است.',
+    'throttle' => 'تعداد دفعات ورود بیش از حد مجاز است. لطفاً :seconds ثانیه دیگر دوباره امتحان کنید.',
+
+];

--- a/lang/fa/pagination.php
+++ b/lang/fa/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; قبلی',
+    'next' => 'بعدی &raquo;',
+
+];

--- a/lang/fa/passwords.php
+++ b/lang/fa/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'رمز عبور شما بازنشانی شد.',
+    'sent' => 'لینک بازنشانی رمز عبور به ایمیل شما ارسال شد.',
+    'throttled' => 'لطفاً قبل از تلاش مجدد صبر کنید.',
+    'token' => 'این توکن بازنشانی رمز عبور نامعتبر است.',
+    'user' => 'کاربری با این آدرس ایمیل یافت نشد.',
+
+];

--- a/lang/fa/validation.php
+++ b/lang/fa/validation.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    'accepted'             => 'فیلد :attribute باید پذیرفته شده باشد.',
+    'active_url'           => 'فیلد :attribute یک آدرس اینترنتی معتبر نیست.',
+    'after'                => 'فیلد :attribute باید تاریخی بعد از :date باشد.',
+    'alpha'                => 'فیلد :attribute فقط می‌تواند شامل حروف باشد.',
+    'alpha_dash'           => 'فیلد :attribute فقط می‌تواند شامل حروف، اعداد، خط تیره و زیرخط باشد.',
+    'alpha_num'            => 'فیلد :attribute فقط می‌تواند شامل حروف و اعداد باشد.',
+    'array'                => 'فیلد :attribute باید یک آرایه باشد.',
+    'boolean'              => 'فیلد :attribute باید درست یا نادرست باشد.',
+    'confirmed'            => 'تأییدیه فیلد :attribute مطابقت ندارد.',
+    'current_password'     => 'رمز عبور فعلی اشتباه است.',
+    'date'                 => 'فیلد :attribute یک تاریخ معتبر نیست.',
+    'email'                => 'فیلد :attribute باید یک آدرس ایمیل معتبر باشد.',
+    'exists'               => 'مقدار انتخاب شده برای فیلد :attribute نامعتبر است.',
+    'file'                 => 'فیلد :attribute باید یک فایل باشد.',
+    'filled'               => 'فیلد :attribute باید دارای مقدار باشد.',
+    'image'                => 'فیلد :attribute باید یک تصویر باشد.',
+    'integer'              => 'فیلد :attribute باید یک عدد صحیح باشد.',
+    'ip'                   => 'فیلد :attribute باید یک آدرس IP معتبر باشد.',
+    'json'                 => 'فیلد :attribute باید یک رشته JSON معتبر باشد.',
+    'numeric'              => 'فیلد :attribute باید یک عدد باشد.',
+    'required'             => 'فیلد :attribute الزامی است.',
+    'same'                 => 'فیلد :attribute و :other باید یکسان باشند.',
+    'string'               => 'فیلد :attribute باید یک رشته متنی باشد.',
+    'unique'               => 'این مقدار برای فیلد :attribute قبلاً ثبت شده است.',
+    'url'                  => 'فیلد :attribute باید یک آدرس اینترنتی معتبر باشد.',
+    'uuid'                 => 'فیلد :attribute باید یک UUID معتبر باشد.',
+
+    'attributes' => [],
+
+];


### PR DESCRIPTION
## Description
Adds Persian (Farsi) language support to Wave by adding translation files for the `fa` locale.

## Changes
- `lang/fa/auth.php` - Authentication messages in Persian
- `lang/fa/pagination.php` - Pagination labels in Persian
- `lang/fa/passwords.php` - Password reset messages in Persian
- `lang/fa/validation.php` - Validation messages in Persian

## Notes
Persian is spoken by 120+ million people. This follows the same structure as the existing `ar` (Arabic) locale already in the project.