### PR TITLE
Disable dark mode on marketing pages so light mode logo appears

### DIFF
--- a/resources/themes/anchor/components/layouts/marketing.blade.php
+++ b/resources/themes/anchor/components/layouts/marketing.blade.php
@@ -3,7 +3,7 @@
 <head>
     @include('theme::partials.head', ['seo' => ($seo ?? null) ])
 </head>
-<body x-data class="flex flex-col min-h-screen overflow-x-hidden @if($bodyClass ?? false){{ $bodyClass }}@endif" x-cloak>
+<body x-data class="flex flex-col min-h-screen overflow-x-hidden @if($bodyClass ?? false){{ $bodyClass }}@endif" x-cloak data-marketing-layout>
 
     <x-marketing.elements.header />
 
@@ -15,6 +15,15 @@
     @include('theme::partials.footer')
     @include('theme::partials.footer-scripts')
     {{ $javascript ?? '' }}
+    <script>
+        function syncThemeForLayout() {
+            const isMarketing =
+                document.body.hasAttribute('data-marketing-layout');
 
+            document.documentElement.classList.toggle('dark', !isMarketing);
+        }
+        document.addEventListener('livewire:navigated', syncThemeForLayout);
+        syncThemeForLayout();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Wave allows you to select both a dark mode and light mode logo for your app. If you log into the user dashboard and enable dark mode, your dark mode features will appear. If you then navigate (using wire:navigate, which all links were converted to this in a previous PR) to a marketing page (home/blog/pricing) the app "shell" is not reloaded so your dark mode logo follows you to a page that has no dark mode. The result is now your logo is appearing in dark mode on a light mode page. In my case, made it invisible. This PR removes dark mode class on the HTML element on marketing pages when navigated to using livewire:navigate. Dark mode remains enabled on pages that support it.