### PR TITLE
Bug fix in syncThemeForLayout function logic

### DIFF
--- a/resources/themes/anchor/components/layouts/marketing.blade.php
+++ b/resources/themes/anchor/components/layouts/marketing.blade.php
@@ -17,10 +17,9 @@
     {{ $javascript ?? '' }}
     <script>
         function syncThemeForLayout() {
-            const isMarketing =
-                document.body.hasAttribute('data-marketing-layout');
-
-            document.documentElement.classList.toggle('dark', !isMarketing);
+            if (document.body.hasAttribute('data-marketing-layout')) {
+                document.documentElement.classList.remove('dark');
+            }
         }
         document.addEventListener('livewire:navigated', syncThemeForLayout);
         syncThemeForLayout();


### PR DESCRIPTION
Fixed logic where dark mode was forced on dashboard pages. Check if page is marketing page and and remove 'dark' class from document element if so. Previous code forced dark mode on dashboard page livewire navigation even if dark mode was not enabled.