### PR TITLE
Redirect guests to login in Subscribed middleware

### DIFF
--- a/wave/src/Http/Middleware/Subscribed.php
+++ b/wave/src/Http/Middleware/Subscribed.php
@@ -15,9 +15,13 @@ class Subscribed
      */
     public function handle(Request $request, Closure $next)
     {
+        if (! Auth::check()) {
+            return redirect()->guest(route('login'));
+        }
+
         $user = auth()->user();
 
-        if (Auth::check() && ($user->subscriber() || $user->isAdmin())) {
+        if ($user->subscriber() || $user->isAdmin()) {
             return $next($request);
         }
 


### PR DESCRIPTION
## Summary
- Check authentication before subscription status in `Subscribed` middleware
- Guests now redirect to `login` with intended URL instead of the billing page

## Motivation
When `subscribed` middleware runs for a guest, the previous logic fell through to `route('billing')`, which is confusing for unauthenticated visitors.

## Test plan
- [ ] Guest hitting a subscribed-protected route redirects to login
- [ ] Authenticated non-subscriber still redirects to billing
- [ ] Authenticated subscriber/admin proceeds normally


Made with [Cursor](https://cursor.com)